### PR TITLE
Add Season 11 placeholder logo and simplify header branding/navigation

### DIFF
--- a/assets/branding/pinnacle-season-11-logo.svg
+++ b/assets/branding/pinnacle-season-11-logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Pinnacle SMP Season 11 logo placeholder</title>
+  <desc id="desc">Replace this file with the final exported logo artwork while keeping the same filename.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1b2a45"/>
+      <stop offset="100%" stop-color="#0e1524"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#57d5ff"/>
+      <stop offset="100%" stop-color="#5fff9c"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="url(#bg)"/>
+  <circle cx="256" cy="190" r="96" fill="none" stroke="url(#accent)" stroke-width="18"/>
+  <path d="M256 108l26 58h64l-52 40 20 64-58-38-58 38 20-64-52-40h64z" fill="#ffd66b"/>
+  <text x="256" y="360" text-anchor="middle" fill="#eef3ff" font-size="58" font-family="Inter,Segoe UI,sans-serif" font-weight="800">Pinnacle</text>
+  <text x="256" y="412" text-anchor="middle" fill="#ffd66b" font-size="46" font-family="Inter,Segoe UI,sans-serif" font-weight="800">SMP S11</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -84,33 +84,11 @@
       text-transform: uppercase;
     }
 
-    .brand-badge {
+    .brand-logo {
       width: 46px;
       height: 46px;
-      border-radius: 14px;
-      background:
-        linear-gradient(135deg, rgba(95,255,156,0.28), rgba(87,213,255,0.18)),
-        #111a2a;
-      border: 1px solid rgba(95,255,156,0.35);
-      box-shadow: inset 0 0 24px rgba(95,255,156,0.08), 0 10px 24px rgba(0,0,0,0.35);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .brand-badge::before,
-    .brand-badge::after {
-      content: "";
-      position: absolute;
-      background: rgba(255,255,255,0.13);
-    }
-
-    .brand-badge::before {
-      inset: 8px;
-      border-radius: 8px;
-      box-shadow:
-        10px 0 0 rgba(255,255,255,0.12),
-        0 10px 0 rgba(255,255,255,0.12),
-        10px 10px 0 rgba(255,255,255,0.06);
+      object-fit: contain;
+      flex-shrink: 0;
     }
 
     .brand span { font-size: 1rem; }
@@ -129,8 +107,7 @@
       position: relative;
     }
 
-    nav > ul > li > a,
-    nav > ul > li > button {
+    nav > ul > li > a {
       appearance: none;
       border: 0;
       background: transparent;
@@ -143,43 +120,12 @@
     }
 
     nav > ul > li > a:hover,
-    nav > ul > li > button:hover,
-    nav > ul > li > a:focus,
-    nav > ul > li > button:focus {
+    nav > ul > li > a:focus {
       background: rgba(122, 162, 255, 0.12);
       color: white;
       outline: none;
     }
 
-    .dropdown-menu {
-      position: absolute;
-      top: calc(100% + 10px);
-      left: 0;
-      min-width: 210px;
-      padding: 10px;
-      background: rgba(10, 14, 22, 0.96);
-      border: 1px solid rgba(122, 162, 255, 0.16);
-      border-radius: 16px;
-      box-shadow: var(--shadow);
-      display: none;
-    }
-
-    .dropdown:hover .dropdown-menu,
-    .dropdown:focus-within .dropdown-menu {
-      display: block;
-    }
-
-    .dropdown-menu a {
-      display: block;
-      padding: 11px 12px;
-      border-radius: 10px;
-      color: var(--muted);
-    }
-
-    .dropdown-menu a:hover {
-      background: rgba(95,255,156,0.1);
-      color: var(--text);
-    }
 
     .hero {
       position: relative;
@@ -509,15 +455,8 @@
         gap: 6px;
       }
 
-      nav > ul > li > a,
-      nav > ul > li > button {
+      nav > ul > li > a {
         padding: 10px 12px;
-      }
-
-      .dropdown-menu {
-        position: static;
-        display: block;
-        margin-top: 8px;
       }
 
       .hero,
@@ -550,7 +489,7 @@
   <header class="site-header">
     <div class="container nav-wrap">
       <a href="#home" class="brand">
-        <div class="brand-badge" aria-hidden="true"></div>
+        <img class="brand-logo" src="assets/branding/pinnacle-season-11-logo.svg" alt="Pinnacle SMP Season 11 logo" />
         <span>Pinnacle SMP</span>
       </a>
 
@@ -558,13 +497,7 @@
         <ul>
           <li><a href="#home">Home</a></li>
           <li><a href="#rules">Server Rules</a></li>
-          <li class="dropdown">
-            <button aria-haspopup="true" aria-expanded="false">Join ▾</button>
-            <div class="dropdown-menu">
-              <a href="#about-us">About Us</a>
-              <a href="#apply-here">Apply Here</a>
-            </div>
-          </li>
+          <li><a href="#join">Join</a></li>
           <li><a href="#news">Server News</a></li>
           <li><a href="#gallery">Gallery</a></li>
         </ul>
@@ -776,7 +709,7 @@
     <div class="container footer-grid">
       <div class="footer-brand">
         <div class="brand" style="margin-bottom: 12px;">
-          <div class="brand-badge" aria-hidden="true"></div>
+          <img class="brand-logo" src="assets/branding/pinnacle-season-11-logo.svg" alt="Pinnacle SMP Season 11 logo" />
           <span>Pinnacle SMP</span>
         </div>
         <p>

--- a/news.html
+++ b/news.html
@@ -82,33 +82,11 @@
       text-transform: uppercase;
     }
 
-    .brand-badge {
+    .brand-logo {
       width: 46px;
       height: 46px;
-      border-radius: 14px;
-      background:
-        linear-gradient(135deg, rgba(95,255,156,0.28), rgba(87,213,255,0.18)),
-        #111a2a;
-      border: 1px solid rgba(95,255,156,0.35);
-      box-shadow: inset 0 0 24px rgba(95,255,156,0.08), 0 10px 24px rgba(0,0,0,0.35);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .brand-badge::before,
-    .brand-badge::after {
-      content: "";
-      position: absolute;
-      background: rgba(255,255,255,0.13);
-    }
-
-    .brand-badge::before {
-      inset: 8px;
-      border-radius: 8px;
-      box-shadow:
-        10px 0 0 rgba(255,255,255,0.12),
-        0 10px 0 rgba(255,255,255,0.12),
-        10px 10px 0 rgba(255,255,255,0.06);
+      object-fit: contain;
+      flex-shrink: 0;
     }
 
     .btn {
@@ -261,7 +239,7 @@
   <header class="site-header">
     <div class="container nav-wrap">
       <a href="index.html#home" class="brand">
-        <div class="brand-badge" aria-hidden="true"></div>
+        <img class="brand-logo" src="assets/branding/pinnacle-season-11-logo.svg" alt="Pinnacle SMP Season 11 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <a class="btn" href="index.html#news">← Back to Home News</a>


### PR DESCRIPTION
### Motivation
- Add a Season 11 logo asset and update the site header to use an actual image for branding instead of decorative CSS-only badge.
- Simplify the header markup and navigation by replacing the dropdown join control with a simple link and streamlining related styles.
- Remove unused/complex badge pseudo-element styles to make the branding easier to replace with final artwork.

### Description
- Adds a placeholder SVG logo at `assets/branding/pinnacle-season-11-logo.svg` containing gradients, badge artwork, and text for the season.
- Replaces the `.brand-badge` div with an `<img class="brand-logo" src="assets/branding/pinnacle-season-11-logo.svg">` in `index.html` and `news.html` and updates the CSS class from `.brand-badge` to `.brand-logo` using `object-fit: contain` and `flex-shrink: 0`.
- Removes dropdown-specific markup and CSS (the `.dropdown` and `.dropdown-menu` behaviors and button selectors) and replaces the menu entry with a plain `Join` link, while adjusting nav link selectors accordingly.

### Testing
- No automated tests were executed for these static markup and asset changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ba13a880832f91220e5f17e699f7)