### PR TITLE
Remove gallery section and all related references

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,6 @@
     }
 
     .news-grid,
-    .gallery-grid,
     .info-grid,
     .join-grid {
       display: grid;
@@ -289,7 +288,6 @@
     }
 
     .news-grid { grid-template-columns: repeat(3, 1fr); }
-    .gallery-grid { grid-template-columns: repeat(4, 1fr); }
     .info-grid { grid-template-columns: repeat(3, 1fr); }
     .join-grid { grid-template-columns: 1fr 1fr; }
 
@@ -338,38 +336,6 @@
       border: 1px solid rgba(255,255,255,0.05);
       padding: 14px 16px;
       border-radius: 16px;
-    }
-
-    .gallery-item {
-      aspect-ratio: 1 / 1;
-      border-radius: 22px;
-      overflow: hidden;
-      border: 1px solid var(--line);
-      position: relative;
-      background:
-        linear-gradient(145deg, rgba(95,255,156,0.14), rgba(87,213,255,0.08)),
-        linear-gradient(180deg, #162033, #0d121c);
-      box-shadow: var(--shadow);
-    }
-
-    .gallery-item::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background:
-        linear-gradient(transparent 0 60%, rgba(0,0,0,0.6)),
-        linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px),
-        linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px);
-      background-size: auto, 24px 24px, 24px 24px;
-    }
-
-    .gallery-label {
-      position: absolute;
-      left: 16px;
-      bottom: 16px;
-      right: 16px;
-      font-weight: 700;
-      z-index: 1;
     }
 
     .about-list {
@@ -433,7 +399,6 @@
       .join-grid,
       .footer-grid,
       .news-grid,
-      .gallery-grid,
       .info-grid {
         grid-template-columns: 1fr 1fr;
       }
@@ -466,7 +431,6 @@
 
       .hero-grid,
       .news-grid,
-      .gallery-grid,
       .info-grid,
       .join-grid,
       .footer-grid,
@@ -499,7 +463,6 @@
           <li><a href="#rules">Server Rules</a></li>
           <li><a href="#join">Join</a></li>
           <li><a href="#news">Server News</a></li>
-          <li><a href="#gallery">Gallery</a></li>
         </ul>
       </nav>
     </div>
@@ -686,23 +649,6 @@
       </div>
     </section>
 
-    <section class="section" id="gallery">
-      <div class="container">
-        <div class="section-heading">
-          <div>
-            <div class="eyebrow">Visual Showcase</div>
-            <h2>Gallery</h2>
-          </div>
-        </div>
-
-        <div class="gallery-grid">
-          <div class="gallery-item"><div class="gallery-label">Spawn District</div></div>
-          <div class="gallery-item"><div class="gallery-label">Season Event Night</div></div>
-          <div class="gallery-item"><div class="gallery-label">Community Mega Build</div></div>
-          <div class="gallery-item"><div class="gallery-label">Member Base Showcase</div></div>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer class="site-footer">

--- a/news.html
+++ b/news.html
@@ -286,7 +286,7 @@
             </p>
             <h3>What happens next</h3>
             <ul>
-              <li>Staff will post a full base showcase in the gallery and Discord highlights.</li>
+              <li>Staff will post a full base showcase in Discord highlights.</li>
               <li>Community spotlight role is assigned for this month.</li>
               <li>Vote submissions for next month open in the final week of April.</li>
             </ul>


### PR DESCRIPTION
### Motivation
- The gallery feature was removed from the site, so all UI, layout, and content references to the gallery needed to be deleted to avoid dead links and unused CSS.

### Description
- Deleted the Gallery navigation link from the main header so the nav no longer points to a removed section. 
- Removed the entire Gallery HTML section from `index.html` so the page flows from the Join section directly to the footer. 
- Removed gallery-specific CSS rules and responsive references (including `.gallery-grid`, `.gallery-item`, and `.gallery-label`) and adjusted grouped grid declarations in `index.html`. 
- Updated the MBH news article in `news.html` to remove the textual reference to the gallery and instead mention Discord highlights.

### Testing
- Ran `rg -n "gallery|Gallery" index.html news.html` to confirm no remaining gallery references in the edited files, and it returned no matches. 
- Inspected the modified files to verify the Gallery HTML and CSS blocks were removed and the news text update is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2beff0874832f89bfbcb40fbb6d02)