### PR TITLE
Add Contact, Ban Appeal, and Plugin Suggestion forms; remove gallery from homepage

### DIFF
--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ban Appeal | Pinnacle SMP</title>
+  <style>
+    :root {
+      --bg: #090b10;
+      --panel: rgba(17, 23, 36, 0.92);
+      --line: rgba(120, 150, 190, 0.18);
+      --text: #eef3ff;
+      --muted: #9ba8c7;
+      --green: #5fff9c;
+      --cyan: #57d5ff;
+      --radius: 20px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #0b0f16 0%, #080a0f 100%);
+      min-height: 100vh;
+    }
+    .container {
+      width: min(calc(100% - 32px), 860px);
+      margin: 0 auto;
+      padding: 36px 0 52px;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 28px;
+    }
+    h1 { margin: 0 0 10px; font-size: clamp(2rem, 4vw, 2.8rem); }
+    p { color: var(--muted); line-height: 1.7; }
+    .note { font-size: 0.95rem; margin: 0 0 22px; }
+    form { display: grid; gap: 16px; }
+    label { font-weight: 600; display: grid; gap: 8px; }
+    input, textarea, select {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid rgba(122, 162, 255, 0.24);
+      background: rgba(10, 14, 22, 0.94);
+      color: var(--text);
+      padding: 12px 14px;
+      font: inherit;
+    }
+    textarea { min-height: 130px; resize: vertical; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
+    .btn {
+      border: 0;
+      border-radius: 12px;
+      min-height: 44px;
+      padding: 0 16px;
+      font-weight: 700;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
+    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="card">
+      <h1>Ban Appeal</h1>
+      <p>
+        Fill out this form to open a pre-filled GitHub issue for staff review. Submitting opens GitHub in a new tab where
+        you can confirm and create the issue.
+      </p>
+      <p class="note">
+        Maintainers: update <code>GITHUB_REPO</code> in this page if your repository path changes.
+      </p>
+
+      <form id="ban-appeal-form">
+        <label>Minecraft Username
+          <input name="mc_username" required />
+        </label>
+
+        <label>Discord Username (optional)
+          <input name="discord_username" placeholder="name or @handle" />
+        </label>
+
+        <label>Date of Ban (if known)
+          <input type="date" name="ban_date" />
+        </label>
+
+        <label>Ban Reason Given
+          <textarea name="ban_reason" required></textarea>
+        </label>
+
+        <label>Why should this ban be appealed?
+          <textarea name="appeal_reason" required></textarea>
+        </label>
+
+        <label>What will you do differently going forward?
+          <textarea name="changes_made" required></textarea>
+        </label>
+
+        <label>Additional Notes
+          <textarea name="additional_notes"></textarea>
+        </label>
+
+        <div class="actions">
+          <button class="btn btn-primary" type="submit">Create GitHub Issue</button>
+          <a class="btn btn-secondary" href="index.html">Back to Home</a>
+        </div>
+      </form>
+    </div>
+  </main>
+
+  <script>
+    const GITHUB_REPO = "OWNER/REPO";
+
+    const form = document.getElementById("ban-appeal-form");
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      if (GITHUB_REPO === "OWNER/REPO") {
+        alert("Please configure GITHUB_REPO in ban-appeal.html before using this form.");
+        return;
+      }
+
+      const data = new FormData(form);
+      const value = (name) => (data.get(name) || "Not provided").toString().trim() || "Not provided";
+      const title = `[Ban Appeal] ${value("mc_username")}`;
+      const body = [
+        "## Ban Appeal Form",
+        "",
+        `- **Minecraft Username:** ${value("mc_username")}`,
+        `- **Discord Username:** ${value("discord_username")}`,
+        `- **Date of Ban:** ${value("ban_date")}`,
+        `- **Ban Reason Given:** ${value("ban_reason")}`,
+        `- **Why should this ban be appealed?:** ${value("appeal_reason")}`,
+        `- **What will you do differently going forward?:** ${value("changes_made")}`,
+        `- **Additional Notes:** ${value("additional_notes")}`
+      ].join("\n");
+
+      const url = `https://github.com/${GITHUB_REPO}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=${encodeURIComponent("ban-appeal")}`;
+      window.open(url, "_blank", "noopener");
+    });
+  </script>
+</body>
+</html>

--- a/contact-us.html
+++ b/contact-us.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact Us | Pinnacle SMP</title>
+  <style>
+    :root {
+      --bg: #090b10;
+      --panel: rgba(17, 23, 36, 0.92);
+      --line: rgba(120, 150, 190, 0.18);
+      --text: #eef3ff;
+      --muted: #9ba8c7;
+      --green: #5fff9c;
+      --cyan: #57d5ff;
+      --radius: 20px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #0b0f16 0%, #080a0f 100%);
+      min-height: 100vh;
+    }
+    .container { width: min(calc(100% - 32px), 860px); margin: 0 auto; padding: 36px 0 52px; }
+    .card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; }
+    h1 { margin: 0 0 10px; font-size: clamp(2rem, 4vw, 2.8rem); }
+    p { color: var(--muted); line-height: 1.7; }
+    .note { font-size: 0.95rem; margin: 0 0 22px; }
+    form { display: grid; gap: 16px; }
+    label { font-weight: 600; display: grid; gap: 8px; }
+    input, textarea, select {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid rgba(122, 162, 255, 0.24);
+      background: rgba(10, 14, 22, 0.94);
+      color: var(--text);
+      padding: 12px 14px;
+      font: inherit;
+    }
+    textarea { min-height: 130px; resize: vertical; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
+    .btn {
+      border: 0;
+      border-radius: 12px;
+      min-height: 44px;
+      padding: 0 16px;
+      font-weight: 700;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
+    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="card">
+      <h1>Contact Us</h1>
+      <p>
+        Use this contact form to open a GitHub issue with your message details for staff follow-up.
+      </p>
+      <p class="note">
+        Maintainers: update <code>GITHUB_REPO</code> in this page if your repository path changes.
+      </p>
+
+      <form id="contact-form">
+        <label>Your Name
+          <input name="name" required />
+        </label>
+
+        <label>Preferred Contact (Discord, email, or both)
+          <input name="contact" required placeholder="Example: user#1234 or you@email.com" />
+        </label>
+
+        <label>Topic
+          <select name="topic" required>
+            <option value="General Question">General Question</option>
+            <option value="Staff Report">Staff Report</option>
+            <option value="Partnership Request">Partnership Request</option>
+            <option value="Technical Help">Technical Help</option>
+            <option value="Other">Other</option>
+          </select>
+        </label>
+
+        <label>Subject
+          <input name="subject" required />
+        </label>
+
+        <label>Message
+          <textarea name="message" required></textarea>
+        </label>
+
+        <div class="actions">
+          <button class="btn btn-primary" type="submit">Create GitHub Issue</button>
+          <a class="btn btn-secondary" href="index.html">Back to Home</a>
+        </div>
+      </form>
+    </div>
+  </main>
+
+  <script>
+    const GITHUB_REPO = "OWNER/REPO";
+
+    const form = document.getElementById("contact-form");
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      if (GITHUB_REPO === "OWNER/REPO") {
+        alert("Please configure GITHUB_REPO in contact-us.html before using this form.");
+        return;
+      }
+
+      const data = new FormData(form);
+      const value = (name) => (data.get(name) || "Not provided").toString().trim() || "Not provided";
+      const title = `[Contact] ${value("subject")}`;
+      const body = [
+        "## Contact Form Submission",
+        "",
+        `- **Name:** ${value("name")}`,
+        `- **Preferred Contact:** ${value("contact")}`,
+        `- **Topic:** ${value("topic")}`,
+        `- **Subject:** ${value("subject")}`,
+        `- **Message:** ${value("message")}`
+      ].join("\n");
+
+      const url = `https://github.com/${GITHUB_REPO}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=${encodeURIComponent("contact")}`;
+      window.open(url, "_blank", "noopener");
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -281,7 +281,6 @@
     }
 
     .news-grid,
-    .gallery-grid,
     .info-grid,
     .join-grid {
       display: grid;
@@ -289,7 +288,6 @@
     }
 
     .news-grid { grid-template-columns: repeat(3, 1fr); }
-    .gallery-grid { grid-template-columns: repeat(4, 1fr); }
     .info-grid { grid-template-columns: repeat(3, 1fr); }
     .join-grid { grid-template-columns: 1fr 1fr; }
 
@@ -338,38 +336,6 @@
       border: 1px solid rgba(255,255,255,0.05);
       padding: 14px 16px;
       border-radius: 16px;
-    }
-
-    .gallery-item {
-      aspect-ratio: 1 / 1;
-      border-radius: 22px;
-      overflow: hidden;
-      border: 1px solid var(--line);
-      position: relative;
-      background:
-        linear-gradient(145deg, rgba(95,255,156,0.14), rgba(87,213,255,0.08)),
-        linear-gradient(180deg, #162033, #0d121c);
-      box-shadow: var(--shadow);
-    }
-
-    .gallery-item::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background:
-        linear-gradient(transparent 0 60%, rgba(0,0,0,0.6)),
-        linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px),
-        linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px);
-      background-size: auto, 24px 24px, 24px 24px;
-    }
-
-    .gallery-label {
-      position: absolute;
-      left: 16px;
-      bottom: 16px;
-      right: 16px;
-      font-weight: 700;
-      z-index: 1;
     }
 
     .about-list {
@@ -433,7 +399,6 @@
       .join-grid,
       .footer-grid,
       .news-grid,
-      .gallery-grid,
       .info-grid {
         grid-template-columns: 1fr 1fr;
       }
@@ -466,7 +431,6 @@
 
       .hero-grid,
       .news-grid,
-      .gallery-grid,
       .info-grid,
       .join-grid,
       .footer-grid,
@@ -499,7 +463,6 @@
           <li><a href="#rules">Server Rules</a></li>
           <li><a href="#join">Join</a></li>
           <li><a href="#news">Server News</a></li>
-          <li><a href="#gallery">Gallery</a></li>
         </ul>
       </nav>
     </div>
@@ -686,23 +649,6 @@
       </div>
     </section>
 
-    <section class="section" id="gallery">
-      <div class="container">
-        <div class="section-heading">
-          <div>
-            <div class="eyebrow">Visual Showcase</div>
-            <h2>Gallery</h2>
-          </div>
-        </div>
-
-        <div class="gallery-grid">
-          <div class="gallery-item"><div class="gallery-label">Spawn District</div></div>
-          <div class="gallery-item"><div class="gallery-label">Season Event Night</div></div>
-          <div class="gallery-item"><div class="gallery-label">Community Mega Build</div></div>
-          <div class="gallery-item"><div class="gallery-label">Member Base Showcase</div></div>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer class="site-footer">
@@ -721,10 +667,10 @@
       <div class="footer-col">
         <h4>Membership</h4>
         <div class="footer-links">
-          <a href="#">Ban Appeal</a>
+          <a href="ban-appeal.html">Ban Appeal</a>
           <a href="#about-us">About Us</a>
           <a href="#apply-here">Apply Here</a>
-          <a href="#">Plugin Suggestions</a>
+          <a href="plugin-suggestions.html">Plugin Suggestions</a>
           <a href="#rules">Server Rules</a>
           <a href="#news">Server News</a>
         </div>
@@ -733,7 +679,7 @@
       <div class="footer-col">
         <h4>Contact</h4>
         <div class="footer-links">
-          <a href="#">Contact Us</a>
+          <a href="contact-us.html">Contact Us</a>
           <a href="#">FAQs</a>
           <a href="#">How to Play</a>
         </div>

--- a/news.html
+++ b/news.html
@@ -286,7 +286,7 @@
             </p>
             <h3>What happens next</h3>
             <ul>
-              <li>Staff will post a full base showcase in the gallery and Discord highlights.</li>
+              <li>Staff will post a full base showcase in Discord highlights.</li>
               <li>Community spotlight role is assigned for this month.</li>
               <li>Vote submissions for next month open in the final week of April.</li>
             </ul>

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Plugin Suggestions | Pinnacle SMP</title>
+  <style>
+    :root {
+      --bg: #090b10;
+      --panel: rgba(17, 23, 36, 0.92);
+      --line: rgba(120, 150, 190, 0.18);
+      --text: #eef3ff;
+      --muted: #9ba8c7;
+      --green: #5fff9c;
+      --cyan: #57d5ff;
+      --radius: 20px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #0b0f16 0%, #080a0f 100%);
+      min-height: 100vh;
+    }
+    .container { width: min(calc(100% - 32px), 860px); margin: 0 auto; padding: 36px 0 52px; }
+    .card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; }
+    h1 { margin: 0 0 10px; font-size: clamp(2rem, 4vw, 2.8rem); }
+    p { color: var(--muted); line-height: 1.7; }
+    .note { font-size: 0.95rem; margin: 0 0 22px; }
+    form { display: grid; gap: 16px; }
+    label { font-weight: 600; display: grid; gap: 8px; }
+    input, textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid rgba(122, 162, 255, 0.24);
+      background: rgba(10, 14, 22, 0.94);
+      color: var(--text);
+      padding: 12px 14px;
+      font: inherit;
+    }
+    textarea { min-height: 130px; resize: vertical; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
+    .btn {
+      border: 0;
+      border-radius: 12px;
+      min-height: 44px;
+      padding: 0 16px;
+      font-weight: 700;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
+    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="card">
+      <h1>Plugin Suggestions</h1>
+      <p>
+        Share plugin ideas that could improve the server. This form opens a GitHub issue pre-filled with your answers.
+      </p>
+      <p class="note">
+        Maintainers: update <code>GITHUB_REPO</code> in this page if your repository path changes.
+      </p>
+
+      <form id="plugin-suggestion-form">
+        <label>Your Name / Username
+          <input name="submitter" placeholder="Optional" />
+        </label>
+
+        <label>Plugin Name
+          <input name="plugin_name" required />
+        </label>
+
+        <label>Plugin Link
+          <input name="plugin_link" type="url" placeholder="https://..." />
+        </label>
+
+        <label>What problem does this solve?
+          <textarea name="problem" required></textarea>
+        </label>
+
+        <label>How should this plugin be configured for Pinnacle SMP?
+          <textarea name="configuration" required></textarea>
+        </label>
+
+        <label>Main Benefits
+          <textarea name="benefits" required></textarea>
+        </label>
+
+        <label>Potential Downsides / Risks
+          <textarea name="risks"></textarea>
+        </label>
+
+        <div class="actions">
+          <button class="btn btn-primary" type="submit">Create GitHub Issue</button>
+          <a class="btn btn-secondary" href="index.html">Back to Home</a>
+        </div>
+      </form>
+    </div>
+  </main>
+
+  <script>
+    const GITHUB_REPO = "OWNER/REPO";
+
+    const form = document.getElementById("plugin-suggestion-form");
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      if (GITHUB_REPO === "OWNER/REPO") {
+        alert("Please configure GITHUB_REPO in plugin-suggestions.html before using this form.");
+        return;
+      }
+
+      const data = new FormData(form);
+      const value = (name) => (data.get(name) || "Not provided").toString().trim() || "Not provided";
+      const title = `[Plugin Suggestion] ${value("plugin_name")}`;
+      const body = [
+        "## Plugin Suggestion Form",
+        "",
+        `- **Submitter:** ${value("submitter")}`,
+        `- **Plugin Name:** ${value("plugin_name")}`,
+        `- **Plugin Link:** ${value("plugin_link")}`,
+        `- **What problem does this solve?:** ${value("problem")}`,
+        `- **How should this be configured?:** ${value("configuration")}`,
+        `- **Main benefits:** ${value("benefits")}`,
+        `- **Potential downsides / risks:** ${value("risks")}`
+      ].join("\n");
+
+      const url = `https://github.com/${GITHUB_REPO}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=${encodeURIComponent("plugin-suggestion")}`;
+      window.open(url, "_blank", "noopener");
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide staff-facing submission forms so visitors can open pre-filled GitHub issues for contact, ban appeals, and plugin suggestions. 
- Simplify the homepage by removing the unused gallery to focus navigation on functional pages.

### Description
- Added three new static pages: `contact-us.html`, `ban-appeal.html`, and `plugin-suggestions.html`, each containing a styled form that opens a pre-filled GitHub issue and using a `GITHUB_REPO` placeholder that maintainers must configure. 
- Updated `index.html` to remove the gallery section and related CSS rules, removed the gallery nav/footer link, and updated footer links to point to the new `ban-appeal.html`, `contact-us.html`, and `plugin-suggestions.html` pages. 
- Minor content edit in `news.html` to change a line about posting the MBH winner showcase to mention Discord highlights instead of the gallery. 
- Forms use client-side JavaScript to assemble issue `title`, `body`, and `labels` and open the GitHub issue creation URL in a new tab.

### Testing
- No automated tests were executed for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2beff0874832f89bfbcb40fbb6d02)