### PR TITLE
Responsive horizontal padding and subtitle cleanup on vote-links page

### DIFF
--- a/vote-links.html
+++ b/vote-links.html
@@ -54,8 +54,8 @@
     .container {
       width: min(calc(100% - 32px), 1200px);
       margin: 0 auto;
-      padding: 34px 0 48px;
-          background: rgba(15, 22, 36, 0.62);
+      padding: 34px clamp(18px, 3vw, 40px) 48px;
+      background: rgba(15, 22, 36, 0.62);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -176,7 +176,7 @@
     <a href="index.html" class="back-link">← Back to home</a>
     <h1>Vote Constellation</h1>
     <p class="subtitle">
-      Instead of a plain link list, each star below is a voting portal. Cast your vote and help Pinnacle SMP rise through every ranking galaxy.
+      Cast your vote and help Pinnacle SMP rise through every ranking galaxy.
     </p>
 
     <section class="vote-galaxy" aria-label="Vote links">


### PR DESCRIPTION
### Motivation
- Improve the layout on narrow viewports and tighten the vote page copy for clarity.

### Description
- Replace fixed horizontal padding on `.container` with `padding: 34px clamp(18px, 3vw, 40px) 48px` to provide responsive side padding.
- Shorten the subtitle copy to `Cast your vote and help Pinnacle SMP rise through every ranking galaxy.` for a more concise message.
- No other structural or behavioral changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d43a66b7b0832f84452b17e893c858)