### PR TITLE
Add Season 12 announcement, update news list, and remove 26.1 article

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,6 +651,15 @@
         <div class="news-grid">
           <article class="card news-card hover-lift fade-in slide-up">
             <span class="tag">Announcement</span>
+            <h3>Season 12 Has Begun</h3>
+            <p>
+              Season 12 is live with a brand-new world and a 3,000-block border from spawn to keep early progress fair, active, and collaborative.
+            </p>
+            <a href="news.html#news-season-12-has-begun-2026-04-14" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+          </article>
+
+          <article class="card news-card hover-lift fade-in slide-up">
+            <span class="tag">Announcement</span>
             <h3>Update Still In Progress</h3>
             <p>
               "Alpha builds for Paper 26.1.1 are now available. There is still no ETA for a stable build." - Paper Developers...
@@ -668,15 +677,6 @@
             <a href="news.html#news-mbh-winner-2026-04" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>
 
-          <article class="card news-card hover-lift fade-in slide-up">
-            <span class="tag">Minecraft News</span>
-            <h3>26.1 is here!</h3>
-            <p>
-              Minecraft has updated to 26.1 "Tiny Takeover"! The server will not be updaing until Paper and our plugins
-              have updated. This may take a few days or it could take weeks, it is unknown.
-            </p>
-            <a href="news.html#news-minecraft-26-1-update" style="color: var(--cyan); font-weight: 700;">Read more →</a>
-          </article>
 
         </div>
       </div>

--- a/news.html
+++ b/news.html
@@ -270,9 +270,9 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
+        <a href="#news-season-12-has-begun-2026-04-14" style="color: var(--cyan); font-weight: 700;">Season 12 has begun</a> •
         <a href="#news-update-still-in-progress-2026-04-06" style="color: var(--cyan); font-weight: 700;">Update in progress</a> •
         <a href="#news-mbh-winner-2026-04" style="color: var(--cyan); font-weight: 700;">MBH winner</a> •
-        <a href="#news-minecraft-26-1-update" style="color: var(--cyan); font-weight: 700;">Minecraft 26.1</a> •
         <a href="#news-ranks-system-update" style="color: var(--cyan); font-weight: 700;">Ranks update</a>
       </div>
       </div>
@@ -280,6 +280,38 @@
 
     <section>
       <div class="container news-list">
+        <article class="article" id="news-season-12-has-begun-2026-04-14">
+          <header class="article-header">
+            <div class="article-meta">
+              <span class="tag">Announcement</span>
+              <time class="date" datetime="2026-04-14">April 14, 2026</time>
+            </div>
+            <h2>Season 12 Has Begun</h2>
+          </header>
+          <img
+            class="article-image"
+            src="assets/news/minecraft-update.svg"
+            alt="Feature image for the Season 12 launch announcement"
+          />
+          <div class="article-content">
+            <p>
+              Pinnacle SMP Season 12 is officially live! A brand-new world has been generated, giving everyone a fresh start to explore, build, and grow together.
+            </p>
+            <p>
+              To keep progression balanced and the community close-knit early on, a world border has been set at 3,000 blocks from spawn. This ensures:
+            </p>
+            <ul>
+              <li>A more active and connected player base.</li>
+              <li>Fair access to resources for everyone.</li>
+              <li>Stronger early-season collaboration.</li>
+            </ul>
+            <p>
+              The border may expand later in the season, but for now, it’s all about making the most of what’s inside.
+              Jump in, get established, and be part of the beginning of something great. Welcome to Season 12.
+            </p>
+          </div>
+        </article>
+
         <article class="article" id="news-update-still-in-progress-2026-04-06">
           <header class="article-header">
             <div class="article-meta">
@@ -340,37 +372,6 @@
             <h3>What happens next</h3>
             <ul>
               <li>Vote submissions for next month open in the final week of April.</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="article" id="news-minecraft-26-1-update">
-          <header class="article-header">
-            <div class="article-meta">
-              <span class="tag">Minecraft News</span>
-              <time class="date" datetime="2026-03-31">March 31, 2026</time>
-            </div>
-            <h2>26.1 is here!</h2>
-          </header>
-          <img
-            class="article-image"
-            src="assets/news/minecraft-update.svg"
-            alt="Feature image for the Minecraft 26.1 update"
-          />
-          <div class="article-content">
-            <p>
-              Minecraft has updated to 26.1 "Tiny Takeover". The server will not update until Paper and our plugins
-              are ready. This can take anywhere from a few days to multiple weeks depending on compatibility updates.
-            </p>
-            <p>
-              For the full game changelog, visit the official update article:
-              <a href="https://www.minecraft.net/en-us/article/minecraft-java-edition-26-1" target="_blank" rel="noreferrer" style="color: var(--cyan); font-weight: 700;">Minecraft Java Edition 26.1</a>.
-            </p>
-            <h3>Server compatibility status</h3>
-            <ul>
-              <li>Core server software: waiting for stable Paper build.</li>
-              <li>Essential plugins: update testing in progress.</li>
-              <li>Public rollout: announced after full test pass.</li>
             </ul>
           </div>
         </article>


### PR DESCRIPTION
### Motivation
- Announce the launch of Pinnacle SMP Season 12 and surface the new season details on the home and news pages.
- Keep the news archive current by removing the outdated Minecraft 26.1 article.

### Description
- Added a new news card to `index.html` linking to `#news-season-12-has-begun-2026-04-14` and displaying a short Season 12 summary. 
- Added a full article entry for Season 12 to `news.html` with `id="news-season-12-has-begun-2026-04-14"`, a publication date, image reference, and descriptive content about the 3,000-block border and early-season goals. 
- Updated the news archive jump list in `news.html` to include the new Season 12 anchor and removed references to the removed 26.1 article. 
- Removed the previous Minecraft 26.1 announcement card from the home news grid and the corresponding article from the news archive.

### Testing
- No automated tests were run for these content and static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9470cab8832fa43ee85b64f8a8b2)