### PR TITLE
Add darkened wallpaper background to Pinnacle SMP hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,9 @@
     .hero-card {
       padding: 36px;
       background:
-        linear-gradient(135deg, rgba(87,213,255,0.12), rgba(95,255,156,0.09)),
-        linear-gradient(180deg, rgba(18,24,37,0.96), rgba(11,15,24,0.96));
+        linear-gradient(145deg, rgba(9, 14, 23, 0.72), rgba(8, 12, 20, 0.78)),
+        linear-gradient(180deg, rgba(7, 10, 17, 0.42), rgba(7, 10, 17, 0.62)),
+        url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
     }
 
     .eyebrow {


### PR DESCRIPTION
### Motivation
- Apply the requested branding artwork to the homepage hero so the “Build higher on Pinnacle SMP” section matches site branding. 
- Ensure the wallpaper does not reduce text contrast by dimming it with overlays.

### Description
- Modified the `.hero-card` CSS in `index.html` to include `url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg")` as the section background. 
- Added darker gradient overlays (`linear-gradient(145deg, rgba(9, 14, 23, 0.72), rgba(8, 12, 20, 0.78))` and `linear-gradient(180deg, rgba(7, 10, 17, 0.42), rgba(7, 10, 17, 0.62))`) above the wallpaper to keep foreground text readable.

### Testing
- Ran `git diff -- index.html` to verify the CSS changes were applied and the new background entry is present, which succeeded. 
- Ran `git status --short` to confirm `index.html` was modified and committed, which succeeded. 
- No automated visual or unit tests were run because this is a static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dffdc4172c832fa3b3ecad43170312)