### PR TITLE
Add About Season 12 page and update homepage CTA

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About Season 12 | Pinnacle SMP</title>
+  <style>
+    :root {
+      --panel: rgba(24, 33, 52, 0.82);
+      --line: rgba(156, 191, 236, 0.3);
+      --text: #eef3ff;
+      --muted: #c2cdea;
+      --cyan: #57d5ff;
+      --green: #5fff9c;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+      background: #0f1420;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: -18px;
+      z-index: -2;
+      pointer-events: none;
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
+      filter: blur(7px) brightness(0.48) saturate(1.1);
+      transform: scale(1.03);
+    }
+
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
+        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
+        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+    }
+
+    .container {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 28px auto 52px;
+      padding: 30px;
+      background: rgba(15, 22, 36, 0.62);
+      border: 1px solid rgba(162, 196, 255, 0.2);
+      border-radius: 26px;
+      backdrop-filter: blur(8px);
+    }
+
+    .back-link {
+      display: inline-flex;
+      margin-bottom: 20px;
+      color: var(--cyan);
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      padding: 30px;
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+    }
+
+    h1 {
+      margin: 0 0 16px;
+      font-size: clamp(2rem, 4.5vw, 3rem);
+      letter-spacing: -0.03em;
+    }
+
+    h2 {
+      margin: 28px 0 10px;
+      font-size: clamp(1.3rem, 2.8vw, 1.9rem);
+      color: var(--green);
+    }
+
+    p {
+      margin: 0;
+      line-height: 1.75;
+      color: var(--muted);
+    }
+
+    ul {
+      margin: 10px 0 0 22px;
+      color: var(--muted);
+      line-height: 1.75;
+      padding: 0;
+    }
+
+    li + li { margin-top: 6px; }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <a href="index.html" class="back-link">← Back to home</a>
+
+    <section class="panel">
+      <h1>Pinnacle SMP — Season 12 Overview</h1>
+
+      <h2>Season Start</h2>
+      <p>
+        Season 12 began in April 2026, marking a fresh world reset and a new chapter for the server. As with previous seasons, the focus is on long-term world building, player-driven projects, and organic progression.
+      </p>
+
+      <h2>World Setup</h2>
+      <ul>
+        <li>The world is currently running as a pure vanilla survival experience.</li>
+        <li>This allows for a clean, traditional Minecraft experience during early progression.</li>
+        <li>A transition to Paper (version 26.1.2) is planned once it becomes available. This upgrade will primarily support performance improvements and server stability while maintaining the vanilla feel.</li>
+      </ul>
+
+      <h2>World Border</h2>
+      <ul>
+        <li>The world border is set to 3000 blocks across.</li>
+        <li>
+          This creates a more condensed world, encouraging:
+          <ul>
+            <li>Player interaction.</li>
+            <li>Shared infrastructure.</li>
+            <li>A more connected community layout.</li>
+          </ul>
+        </li>
+      </ul>
+      <p style="margin-top: 10px;">
+        The border is not permanent. A server vote may take place later in the season to determine whether it should be expanded or removed.
+      </p>
+
+      <h2>Spawn Town Development</h2>
+      <p>
+        Spawn is currently in active development as players begin shaping the central hub of the world.
+      </p>
+      <ul>
+        <li>Early builds and infrastructure are starting to take form.</li>
+        <li>Roads, starter buildings, and communal areas are gradually being established.</li>
+        <li>Spawn is expected to evolve naturally as the season progresses.</li>
+      </ul>
+      <p style="margin-top: 10px;">
+        Rather than being pre-built, spawn town is community-driven, reflecting the style and creativity of active players.
+      </p>
+
+      <h2>Season Philosophy</h2>
+      <p>Season 12 is designed around:</p>
+      <ul>
+        <li>Close proximity gameplay in the early season.</li>
+        <li>Player-built progression rather than pre-defined systems.</li>
+        <li>Minimal interference early on, with technical improvements added later.</li>
+      </ul>
+      <p style="margin-top: 10px;">
+        The goal is to allow the world to develop organically first, before introducing backend enhancements.
+      </p>
+
+      <h2>Looking Ahead</h2>
+      <p>As the season continues:</p>
+      <ul>
+        <li>The world border may change based on community input.</li>
+        <li>The server will transition to Paper 26.1.2 for improved performance.</li>
+        <li>Spawn town and surrounding areas will continue to expand.</li>
+      </ul>
+      <p style="margin-top: 10px;">
+        Season 12 is intentionally structured to start simple and grow over time, both technically and creatively.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@
           </p>
           <div class="cta-row">
             <a class="btn btn-primary hover-lift" href="#apply-here">Apply to Join</a>
-            <a class="btn btn-secondary hover-lift" href="#news">Read Server News</a>
+            <a class="btn btn-secondary hover-lift" href="about-season-12.html">About Season 12</a>
             <a class="btn btn-secondary hover-lift" href="http://pinnaclesmp.mcserv.fun:1041" target="_blank" rel="noreferrer">Live Map</a>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Provide a dedicated page with the Season 12 overview content and surface it from the homepage call-to-action so visitors can quickly read the new season details.
- Replace the previous "Read Server News" CTA with a focused entry point for Season 12 information to reduce navigation friction for new and returning players.

### Description
- Updated the homepage hero secondary button in `index.html` to read "About Season 12" and point to `about-season-12.html` instead of the news section. 
- Added a new `about-season-12.html` page containing the full Pinnacle SMP — Season 12 Overview content (Season Start, World Setup, World Border, Spawn Town Development, Season Philosophy, Looking Ahead) with styling matched to the site. 
- Included a back link to the homepage and nested the World Border bullets for clearer structure.

### Testing
- Verified the updated CTA text and link by running `rg -n "About Season 12|about-season-12.html|Read Server News" index.html about-season-12.html`, which found the new link and page references. 
- Confirmed the modified and new files were present via `git status --short`. 
- Inspected the relevant lines of `index.html` and the full `about-season-12.html` output with `nl`/`sed` to ensure the home hero and new page content render as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0016fe9d8832f9a4ad2af8a9069ee)