### PR TITLE
Disable Live Map button while preserving link

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,18 @@
       color: var(--text);
     }
 
+    .btn-disabled {
+      background: rgba(255,255,255,0.06);
+      border-color: rgba(255,255,255,0.14);
+      color: rgba(230,236,255,0.55);
+      cursor: not-allowed;
+      pointer-events: none;
+      opacity: 0.7;
+      filter: grayscale(0.35);
+      box-shadow: none;
+      transform: none;
+    }
+
     .hover-lift {
       transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, filter 0.25s ease;
       will-change: transform;
@@ -602,7 +614,7 @@
           <div class="cta-row">
             <a class="btn btn-primary hover-lift" href="#apply-here">Apply to Join</a>
             <a class="btn btn-secondary hover-lift" href="about-season-12.html">About Season 12</a>
-            <a class="btn btn-secondary hover-lift" href="http://pinnaclesmp.mcserv.fun:1041" target="_blank" rel="noreferrer">Live Map</a>
+            <a class="btn btn-secondary btn-disabled" href="http://pinnaclesmp.mcserv.fun:1041" target="_blank" rel="noreferrer" aria-disabled="true" tabindex="-1">Live Map</a>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Prevent users from opening the Live Map from the homepage while keeping the original destination URL in the markup for future use or copyability.
- Provide a visual and accessibility-conscious disabled state so the CTA clearly appears inactive and is not keyboard focusable.

### Description
- Added a new `.btn-disabled` CSS rule in `index.html` to present disabled CTAs (muted background, muted text color, `cursor: not-allowed`, `pointer-events: none`, reduced `opacity`, `filter: grayscale`, no shadow, and no transform). 
- Reworked the homepage hero Live Map anchor to use `class="btn btn-secondary btn-disabled"` so it looks disabled while leaving the `href` attribute intact. 
- Added accessibility attributes `aria-disabled="true"` and `tabindex="-1"` on the Live Map link to remove it from keyboard focus and signal the disabled state.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0061e960c832f84d0917ad5335f87)