### PR TITLE
Add members page with roster sections and homepage links

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,6 +794,7 @@
             </ul>
             <div class="cta-row">
               <a class="btn btn-secondary hover-lift" href="about-us.html">Learn more</a>
+              <a class="btn btn-secondary hover-lift" href="members.html">View Members</a>
             </div>
           </article>
 
@@ -839,6 +840,7 @@
         <div class="footer-links">
           <a href="ban-appeal.html">Ban Appeal</a>
           <a href="about-us.html">About Us</a>
+          <a href="members.html">Members</a>
           <a href="tournament-standings.html">Tournament Standings</a>
           <a href="plugin-suggestions.html">Plugin Suggestions</a>
           <a href="#rules">Server Rules</a>

--- a/members.html
+++ b/members.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Members | Pinnacle SMP</title>
+  <style>
+    :root {
+      --panel: rgba(24, 33, 52, 0.82);
+      --line: rgba(156, 191, 236, 0.3);
+      --text: #eef3ff;
+      --muted: #c2cdea;
+      --cyan: #57d5ff;
+      --green: #5fff9c;
+      --gold: #ffd66b;
+      --blue: #7aa2ff;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+      background: #0f1420;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: -18px;
+      z-index: -2;
+      pointer-events: none;
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
+      filter: blur(7px) brightness(0.48) saturate(1.1);
+      transform: scale(1.03);
+    }
+
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
+        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
+        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+    }
+
+    .container {
+      width: min(calc(100% - 32px), 1120px);
+      margin: 0 auto;
+      padding: 36px 0 54px;
+      background: rgba(15, 22, 36, 0.62);
+      border: 1px solid rgba(162, 196, 255, 0.2);
+      border-radius: 26px;
+      backdrop-filter: blur(8px);
+    }
+
+    .back-link {
+      display: inline-flex;
+      margin-bottom: 22px;
+      color: var(--cyan);
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      padding: 30px;
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+    }
+
+    .hero-logo {
+      width: min(100%, 560px);
+      margin: 0 auto 24px;
+      filter: drop-shadow(0 14px 22px rgba(87, 213, 255, 0.18));
+    }
+
+    h1 {
+      margin: 0 0 14px;
+      font-size: clamp(2rem, 5vw, 3.2rem);
+      letter-spacing: -0.03em;
+    }
+
+    .intro {
+      margin: 0 0 22px;
+      line-height: 1.8;
+      color: var(--muted);
+    }
+
+    .member-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .member-section {
+      border: 1px solid rgba(156, 191, 236, 0.25);
+      border-radius: 16px;
+      padding: 18px;
+      background: rgba(11, 16, 28, 0.4);
+    }
+
+    .member-section h2 {
+      margin: 0 0 12px;
+      font-size: 1.3rem;
+      color: var(--gold);
+    }
+
+    .member-section.legacy h2 { color: var(--green); }
+    .member-section.full h2 { color: var(--cyan); }
+    .member-section.new h2 { color: var(--blue); }
+
+    ul {
+      margin: 0;
+      padding-left: 18px;
+      line-height: 1.8;
+      color: var(--muted);
+    }
+
+    @media (max-width: 780px) {
+      .member-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <a href="index.html#join" class="back-link">← Back to home</a>
+
+    <section class="panel">
+      <center><img class="hero-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP logo" /></center>
+      <h1>Pinnacle SMP Members</h1>
+      <p class="intro">Meet the current roster of Pinnacle SMP members, grouped by membership status.</p>
+
+      <div class="member-grid">
+        <section class="member-section founding">
+          <h2>Founding Members</h2>
+          <ul>
+            <li>McCreeper318</li>
+            <li>Johnnykilroy</li>
+            <li>Piff</li>
+            <li>Jeff</li>
+          </ul>
+        </section>
+
+        <section class="member-section legacy">
+          <h2>Legacy Members</h2>
+          <ul>
+            <li>BeansUniverse</li>
+            <li>MoeBe10</li>
+            <li>rad1709 (IronArmored)</li>
+            <li>GodlyCris</li>
+          </ul>
+        </section>
+
+        <section class="member-section full">
+          <h2>Full Members</h2>
+          <ul>
+            <li>atlaskytan</li>
+            <li>BadFiction</li>
+            <li>pinapple_pete</li>
+            <li>mermaidxellie</li>
+            <li>misfiired</li>
+            <li>notnownotnever</li>
+            <li>Poplar (Shiny)</li>
+            <li>Beslife</li>
+            <li>Nicolatte (Nic/Duck)</li>
+            <li>StirfrySurprise</li>
+            <li>kylethecaver</li>
+            <li>Kananers</li>
+            <li>BaconcuzBacon</li>
+            <li>Aryamii</li>
+            <li>towofu</li>
+            <li>BraneFX</li>
+            <li>Kelly_E</li>
+          </ul>
+        </section>
+
+        <section class="member-section new">
+          <h2>New Members</h2>
+          <ul>
+            <li>NateOnGuitar</li>
+          </ul>
+        </section>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated members roster so visitors can see the server roster grouped by status. 
- Surface the new page from the homepage and footer to improve discoverability.

### Description
- Add a new `members.html` page that lists Founding Members, Legacy Members, Full Members, and New Members with responsive styling that matches the site.
- Insert a "View Members" button in the Join/About card on `index.html` linking to `members.html`.
- Add a `Members` link to the homepage footer under the Membership column for quick navigation.
- Ensure the members list contains the exact names provided and that the page layout is mobile-responsive.

### Testing
- Ran `git diff --check` to validate there are no trailing whitespace or conflict markers, and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e106642c94832f9f5a768f102511b1)