### PR TITLE
Refresh members page colors/layout and add monthly award section

### DIFF
--- a/members.html
+++ b/members.html
@@ -14,6 +14,8 @@
       --green: #5fff9c;
       --gold: #ffd66b;
       --blue: #7aa2ff;
+      --red: #ff6b6b;
+      --purple: #c48dff;
     }
 
     * { box-sizing: border-box; }
@@ -76,12 +78,6 @@
       box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
     }
 
-    .hero-logo {
-      width: min(100%, 560px);
-      margin: 0 auto 24px;
-      filter: drop-shadow(0 14px 22px rgba(87, 213, 255, 0.18));
-    }
-
     h1 {
       margin: 0 0 14px;
       font-size: clamp(2rem, 5vw, 3.2rem);
@@ -110,12 +106,61 @@
     .member-section h2 {
       margin: 0 0 12px;
       font-size: 1.3rem;
-      color: var(--gold);
+      color: var(--red);
     }
 
-    .member-section.legacy h2 { color: var(--green); }
-    .member-section.full h2 { color: var(--cyan); }
-    .member-section.new h2 { color: var(--blue); }
+    .member-section.legacy h2 { color: var(--purple); }
+    .member-section.full h2 { color: var(--blue); }
+    .member-section.new h2 { color: var(--green); }
+
+    .member-section.full ul {
+      column-count: 2;
+      column-gap: 22px;
+      padding-left: 0;
+      list-style-position: inside;
+      line-height: 1.5;
+    }
+
+    .member-section.full li {
+      break-inside: avoid;
+      margin-bottom: 4px;
+    }
+
+    .awards-panel {
+      margin-top: 22px;
+      border: 1px solid rgba(156, 191, 236, 0.25);
+      border-radius: 16px;
+      padding: 22px 18px;
+      background: rgba(11, 16, 28, 0.4);
+      text-align: center;
+    }
+
+    .awards-panel h2 {
+      margin: 0 0 18px;
+      color: var(--gold);
+      font-size: 1.35rem;
+    }
+
+    .award-highlight {
+      width: min(100%, 520px);
+      margin: 0 auto;
+      border-radius: 14px;
+      border: 1px solid rgba(122, 162, 255, 0.35);
+      padding: 16px;
+      background: rgba(122, 162, 255, 0.1);
+    }
+
+    .award-highlight h3 {
+      margin: 0 0 8px;
+      color: var(--blue);
+      font-size: 1.1rem;
+    }
+
+    .award-highlight p {
+      margin: 0;
+      color: var(--text);
+      font-weight: 600;
+    }
 
     ul {
       margin: 0;
@@ -128,6 +173,10 @@
       .member-grid {
         grid-template-columns: 1fr;
       }
+
+      .member-section.full ul {
+        column-count: 1;
+      }
     }
   </style>
 </head>
@@ -136,7 +185,6 @@
     <a href="index.html#join" class="back-link">← Back to home</a>
 
     <section class="panel">
-      <center><img class="hero-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP logo" /></center>
       <h1>Pinnacle SMP Members</h1>
       <p class="intro">Meet the current roster of Pinnacle SMP members, grouped by membership status.</p>
 
@@ -191,6 +239,14 @@
           </ul>
         </section>
       </div>
+
+      <section class="awards-panel">
+        <h2>Monthly Member Awards</h2>
+        <div class="award-highlight">
+          <h3>Member Base Highlight</h3>
+          <p>April 2026: pinapple_pete</p>
+        </div>
+      </section>
     </section>
   </main>
 </body>


### PR DESCRIPTION
### Motivation
- Align member section heading colors with the requested palette (Founding = red, Legacy = purple, Full = blue, New = green). 
- Make the Full Members list more compact for readability and add a Monthly Member Awards area including a centered Member Base Highlight. 
- Remove the large branding image at the top to start the page directly with the title/introduction. 

### Description
- Added CSS variables `--red` and `--purple` and updated `.member-section` heading colors to match the new palette and `.member-section.new` to use green. 
- Removed the top `.hero-logo` image element from the page markup so the page begins with the heading and intro. 
- Made the Full Members list more compact by applying a two-column list layout on desktop (`.member-section.full ul` with `column-count: 2`) and reverting to one column on small screens. 
- Added a new `section.awards-panel` under the member grid containing a centered `award-highlight` card with `Member Base Highlight` set to `April 2026: pinapple_pete`. 

### Testing
- Parsed the updated `members.html` using Python's `html.parser` to verify it is syntactically valid and the parser completed successfully. 
- Attempted to run `xmllint --html --noout members.html` but the check could not be performed because `xmllint` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e109b2d300832fb19e7e1ca5a0e35f)