### PR TITLE
Adjust navbar button sizing and alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,20 @@
       margin-top: 28px;
     }
 
+    .nav-buttons {
+      margin-top: 0;
+      gap: 10px;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .nav-buttons .btn {
+      min-height: 42px;
+      padding: 0 15px;
+      border-radius: 12px;
+      font-size: 0.95rem;
+    }
+
     .btn {
       display: inline-flex;
       align-items: center;
@@ -552,8 +566,14 @@
         gap: 6px;
       }
 
-      nav > ul > li > a {
-        padding: 10px 12px;
+      .nav-buttons {
+        width: 100%;
+        justify-content: flex-start;
+      }
+
+      .nav-buttons .btn {
+        min-height: 40px;
+        padding: 0 13px;
       }
 
       .hero,
@@ -590,7 +610,7 @@
       </a>
 
       <nav aria-label="Main navigation">
-        <div class="cta-row">
+        <div class="cta-row nav-buttons">
               <a class="btn btn-secondary hover-lift" href="#home">Home</a>
               <a class="btn btn-secondary hover-lift" href="#news">Server News</a>
               <a class="btn btn-secondary hover-lift" href="#events">Events</a>


### PR DESCRIPTION
### Motivation
- Reduce the visual footprint of the header navigation so the buttons sit more centered on the top bar and do not inherit the larger spacing used by content call-to-action rows.
- Keep the existing button look-and-feel (including `btn`, `btn-secondary`, and `hover-lift` behaviors) while making the header controls slightly smaller and more compact.
- Ensure the compact header nav still behaves correctly on narrow screens when the header stacks vertically.

### Description
- Added a `.nav-buttons` container variant and CSS rules to override the larger `.cta-row` spacing for the header nav. 
- Reduced nav button metrics via `.nav-buttons .btn` changes: lowered `min-height`, decreased horizontal `padding`, slightly reduced `border-radius`, and set a modest `font-size` reduction. 
- Added responsive overrides under `@media (max-width: 760px)` to keep nav buttons compact and aligned when the header stacks. 
- Applied `.nav-buttons` to the header nav markup so the new styles affect the top navigation; only `index.html` was modified.

### Testing
- Ran `git diff --check` which returned no issues.
- No other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e139edb1ec832f9781f268fe53229d)