### PR TITLE
Improve mobile responsiveness for home and news pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,10 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
     }
+    main .container {
+      width: 100%;
+      max-width: none;
+    }
     main {
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
@@ -549,16 +553,45 @@
         grid-template-columns: 1fr 1fr;
       }
 
+      .status-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
       .footer-grid > :first-child {
         grid-column: 1 / -1;
       }
     }
 
     @media (max-width: 760px) {
+      .container,
+      main {
+        width: min(calc(100% - 20px), var(--max));
+      }
+
+      main {
+        margin-top: 16px;
+        padding: 6px 12px 20px;
+      }
+
       .nav-wrap {
         align-items: flex-start;
         flex-direction: column;
         padding: 14px 0;
+      }
+
+      .brand {
+        width: 100%;
+        gap: 10px;
+      }
+
+      .brand span {
+        font-size: 0.95rem;
+        letter-spacing: 0.06em;
+      }
+
+      .brand-logo {
+        width: 42px;
+        height: 42px;
       }
 
       nav ul {
@@ -568,12 +601,16 @@
 
       .nav-buttons {
         width: 100%;
-        justify-content: flex-start;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        justify-content: stretch;
       }
 
       .nav-buttons .btn {
+        width: 100%;
         min-height: 40px;
         padding: 0 13px;
+        font-size: 0.9rem;
       }
 
       .hero,
@@ -598,6 +635,28 @@
 
       h1 { max-width: none; }
       .mobile-note { display: block; }
+    }
+
+    @media (max-width: 480px) {
+      .nav-buttons {
+        grid-template-columns: 1fr;
+      }
+
+      .hero-card,
+      .stats-card,
+      .card,
+      .server-card {
+        padding: 18px;
+      }
+
+      .events-table th,
+      .events-table td {
+        padding: 12px 14px;
+      }
+
+      .server-ip {
+        font-size: 1rem;
+      }
     }
   </style>
 </head>

--- a/news.html
+++ b/news.html
@@ -62,6 +62,10 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
     }
+    main .container {
+      width: 100%;
+      max-width: none;
+    }
     main {
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
@@ -246,6 +250,35 @@
     }
 
     @media (max-width: 760px) {
+      .container,
+      main {
+        width: min(calc(100% - 20px), var(--max));
+      }
+
+      main {
+        margin-top: 16px;
+        padding: 6px 12px 20px;
+      }
+
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        gap: 12px;
+      }
+
+      .brand {
+        width: 100%;
+      }
+
+      .brand-logo {
+        width: 42px;
+        height: 42px;
+      }
+
+      .btn {
+        width: 100%;
+      }
+
       .hero { padding-top: 30px; }
       .article-header,
       .article-content { padding-left: 18px; padding-right: 18px; }


### PR DESCRIPTION
### Motivation
- The main page content was visually cramped on narrow screens because nested containers were double-constraining width and large paddings made cards and nav items clip on mobile devices.
- The news page and header controls needed matching mobile-friendly behavior so navigation and back buttons don't feel cramped on phones.

### Description
- Modified `index.html` and `news.html` to add `main .container { width: 100%; max-width: none; }` so inner sections can use full available width on small screens.
- Adjusted the responsive CSS at `@media (max-width: 1100px)` and `@media (max-width: 760px)` to collapse `status-grid` earlier, reduce `main` margins/padding, and loosen container sizing to avoid double-padding.
- Reworked header/brand/nav styles on small screens by scaling the brand/logo and switching the home page navigation buttons to a responsive grid (two columns on small phones, one column below 480px) with full-width buttons.
- Added extra small-screen tweaks (inside `@media (max-width: 480px)`) to reduce card padding, tighten event table cell padding, and scale down the server IP text for better fit.

### Testing
- Parsed both `index.html` and `news.html` with Python's builtin `html.parser` successfully to ensure the documents remain valid HTML for basic parsing.
- Attempted to run `xmllint --html --noout index.html news.html` for stricter validation but the `xmllint` binary is not installed in the environment, so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13c09ae68832fa6f59a132399a17e)