### PR TITLE
Add clickable member profiles and generate profile pages

### DIFF
--- a/members.html
+++ b/members.html
@@ -126,6 +126,36 @@
       margin-bottom: 4px;
     }
 
+    .member-list {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+      display: grid;
+      gap: 8px;
+    }
+
+    .member-button {
+      display: inline-flex;
+      align-items: center;
+      width: 100%;
+      border: 1px solid rgba(122, 162, 255, 0.34);
+      background: rgba(122, 162, 255, 0.1);
+      color: var(--text);
+      text-decoration: none;
+      border-radius: 10px;
+      padding: 8px 10px;
+      font-weight: 600;
+      transition: transform 0.15s ease, border-color 0.2s ease, background-color 0.2s ease;
+    }
+
+    .member-button:hover,
+    .member-button:focus-visible {
+      transform: translateY(-1px);
+      border-color: var(--cyan);
+      background: rgba(87, 213, 255, 0.2);
+      outline: none;
+    }
+
     .awards-panel {
       margin-top: 22px;
       border: 1px solid rgba(156, 191, 236, 0.25);
@@ -191,51 +221,51 @@
       <div class="member-grid">
         <section class="member-section founding">
           <h2>Founding Members</h2>
-          <ul>
-            <li>McCreeper318</li>
-            <li>Johnnykilroy</li>
-            <li>Piff</li>
-            <li>Jeff</li>
+          <ul class="member-list">
+            <li><a class="member-button" href="profiles/McCreeper1318.html">McCreeper1318</a></li>
+            <li><a class="member-button" href="profiles/JohnnyKilroy.html">JohnnyKilroy</a></li>
+            <li><a class="member-button" href="profiles/Piff.html">Piff</a></li>
+            <li><a class="member-button" href="profiles/Jeff.html">Jeff</a></li>
           </ul>
         </section>
 
         <section class="member-section legacy">
           <h2>Legacy Members</h2>
-          <ul>
-            <li>BeansUniverse</li>
-            <li>MoeBe10</li>
-            <li>rad1709 (IronArmored)</li>
-            <li>GodlyCris</li>
+          <ul class="member-list">
+            <li><a class="member-button" href="profiles/BeansUniverse.html">BeansUniverse</a></li>
+            <li><a class="member-button" href="profiles/MoeBe10.html">MoeBe10</a></li>
+            <li><a class="member-button" href="profiles/IronArmored.html">rad1709 (IronArmored)</a></li>
+            <li><a class="member-button" href="profiles/GodlyCris.html">GodlyCris</a></li>
           </ul>
         </section>
 
         <section class="member-section full">
           <h2>Full Members</h2>
-          <ul>
-            <li>atlaskytan</li>
-            <li>BadFiction</li>
-            <li>pinapple_pete</li>
-            <li>mermaidxellie</li>
-            <li>misfiired</li>
-            <li>notnownotnever</li>
-            <li>Poplar (Shiny)</li>
-            <li>Beslife</li>
-            <li>Nicolatte (Nic/Duck)</li>
-            <li>StirfrySurprise</li>
-            <li>kylethecaver</li>
-            <li>Kananers</li>
-            <li>BaconcuzBacon</li>
-            <li>Aryamii</li>
-            <li>towofu</li>
-            <li>BraneFX</li>
-            <li>Kelly_E</li>
+          <ul class="member-list">
+            <li><a class="member-button" href="profiles/Atlaskytan.html">Atlaskytan</a></li>
+            <li><a class="member-button" href="profiles/BadFiction.html">BadFiction</a></li>
+            <li><a class="member-button" href="profiles/pinapple_pete.html">pinapple_pete</a></li>
+            <li><a class="member-button" href="profiles/mermaidxellie.html">mermaidxellie</a></li>
+            <li><a class="member-button" href="profiles/misfiired.html">misfiired</a></li>
+            <li><a class="member-button" href="profiles/notnownotnever.html">notnownotnever</a></li>
+            <li><a class="member-button" href="profiles/Poplare.html">Poplare (Shiny)</a></li>
+            <li><a class="member-button" href="profiles/Beslife.html">Beslife</a></li>
+            <li><a class="member-button" href="profiles/nicholattee.html">nicholattee (Nic/Duck)</a></li>
+            <li><a class="member-button" href="profiles/StirfrySurprise.html">StirfrySurprise</a></li>
+            <li><a class="member-button" href="profiles/kylethecaver.html">kylethecaver</a></li>
+            <li><a class="member-button" href="profiles/Kananers.html">Kananers</a></li>
+            <li><a class="member-button" href="profiles/BACONcuzBACON.html">BACONcuzBACON</a></li>
+            <li><a class="member-button" href="profiles/Aryamii.html">Aryamii</a></li>
+            <li><a class="member-button" href="profiles/t0w0fu.html">t0w0fu</a></li>
+            <li><a class="member-button" href="profiles/BraneFX.html">BraneFX</a></li>
+            <li><a class="member-button" href="profiles/Kelly_E.html">Kelly_E</a></li>
           </ul>
         </section>
 
         <section class="member-section new">
           <h2>New Members</h2>
-          <ul>
-            <li>NateOnGuitar</li>
+          <ul class="member-list">
+            <li><a class="member-button" href="profiles/NateOnGuitar.html">NateOnGuitar</a></li>
           </ul>
         </section>
       </div>

--- a/profiles/Aryamii.html
+++ b/profiles/Aryamii.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Aryamii | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Aryamii.png" alt="Aryamii Minecraft player head" />
+      <div>
+        <h1 class="name">Aryamii</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Atlaskytan.html
+++ b/profiles/Atlaskytan.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Atlaskytan | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Atlaskytan.png" alt="Atlaskytan Minecraft player head" />
+      <div>
+        <h1 class="name">Atlaskytan</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/BACONcuzBACON.html
+++ b/profiles/BACONcuzBACON.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BACONcuzBACON | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/BACONcuzBACON.png" alt="BACONcuzBACON Minecraft player head" />
+      <div>
+        <h1 class="name">BACONcuzBACON</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/BadFiction.html
+++ b/profiles/BadFiction.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BadFiction | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/BadFiction.png" alt="BadFiction Minecraft player head" />
+      <div>
+        <h1 class="name">BadFiction</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/BeansUniverse.html
+++ b/profiles/BeansUniverse.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BeansUniverse | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/BeansUniverse.png" alt="BeansUniverse Minecraft player head" />
+      <div>
+        <h1 class="name">BeansUniverse</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Beslife.html
+++ b/profiles/Beslife.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Beslife | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Beslife.png" alt="Beslife Minecraft player head" />
+      <div>
+        <h1 class="name">Beslife</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/BraneFX.html
+++ b/profiles/BraneFX.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BraneFX | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/BraneFX.png" alt="BraneFX Minecraft player head" />
+      <div>
+        <h1 class="name">BraneFX</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/GodlyCris.html
+++ b/profiles/GodlyCris.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GodlyCris | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/GodlyCris.png" alt="GodlyCris Minecraft player head" />
+      <div>
+        <h1 class="name">GodlyCris</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/IronArmored.html
+++ b/profiles/IronArmored.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>rad1709 (IronArmored) | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/IronArmored.png" alt="rad1709 (IronArmored) Minecraft player head" />
+      <div>
+        <h1 class="name">rad1709 (IronArmored)</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Jeff.html
+++ b/profiles/Jeff.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jeff | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
+      <div>
+        <h1 class="name">Jeff</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/JohnnyKilroy.html
+++ b/profiles/JohnnyKilroy.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JohnnyKilroy | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/JohnnyKilroy.png" alt="JohnnyKilroy Minecraft player head" />
+      <div>
+        <h1 class="name">JohnnyKilroy</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Kananers.html
+++ b/profiles/Kananers.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kananers | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Kananers.png" alt="Kananers Minecraft player head" />
+      <div>
+        <h1 class="name">Kananers</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Kelly_E.html
+++ b/profiles/Kelly_E.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kelly_E | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Kelly_E.png" alt="Kelly_E Minecraft player head" />
+      <div>
+        <h1 class="name">Kelly_E</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/McCreeper1318.html
+++ b/profiles/McCreeper1318.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>McCreeper1318 | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/McCreeper1318.png" alt="McCreeper1318 Minecraft player head" />
+      <div>
+        <h1 class="name">McCreeper1318</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/MoeBe10.html
+++ b/profiles/MoeBe10.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MoeBe10 | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/MoeBe10.png" alt="MoeBe10 Minecraft player head" />
+      <div>
+        <h1 class="name">MoeBe10</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/NateOnGuitar.html
+++ b/profiles/NateOnGuitar.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NateOnGuitar | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
+      <div>
+        <h1 class="name">NateOnGuitar</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Piff.html
+++ b/profiles/Piff.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Piff | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
+      <div>
+        <h1 class="name">Piff</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/Poplare.html
+++ b/profiles/Poplare.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Poplare (Shiny) | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Poplare.png" alt="Poplare (Shiny) Minecraft player head" />
+      <div>
+        <h1 class="name">Poplare (Shiny)</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/StirfrySurprise.html
+++ b/profiles/StirfrySurprise.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>StirfrySurprise | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/StirfrySurprise.png" alt="StirfrySurprise Minecraft player head" />
+      <div>
+        <h1 class="name">StirfrySurprise</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/kylethecaver.html
+++ b/profiles/kylethecaver.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>kylethecaver | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/kylethecaver.png" alt="kylethecaver Minecraft player head" />
+      <div>
+        <h1 class="name">kylethecaver</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/mermaidxellie.html
+++ b/profiles/mermaidxellie.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>mermaidxellie | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/mermaidxellie.png" alt="mermaidxellie Minecraft player head" />
+      <div>
+        <h1 class="name">mermaidxellie</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/misfiired.html
+++ b/profiles/misfiired.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>misfiired | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/misfiired.png" alt="misfiired Minecraft player head" />
+      <div>
+        <h1 class="name">misfiired</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/nicholattee.html
+++ b/profiles/nicholattee.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>nicholattee (Nic/Duck) | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/nicholattee.png" alt="nicholattee (Nic/Duck) Minecraft player head" />
+      <div>
+        <h1 class="name">nicholattee (Nic/Duck)</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/notnownotnever.html
+++ b/profiles/notnownotnever.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>notnownotnever | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/notnownotnever.png" alt="notnownotnever Minecraft player head" />
+      <div>
+        <h1 class="name">notnownotnever</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/pinapple_pete.html
+++ b/profiles/pinapple_pete.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>pinapple_pete | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/pinapple_pete.png" alt="pinapple_pete Minecraft player head" />
+      <div>
+        <h1 class="name">pinapple_pete</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -1,0 +1,145 @@
+:root {
+  --bg1: #0b1020;
+  --bg2: #151d33;
+  --panel: rgba(18, 25, 44, 0.88);
+  --line: rgba(121, 165, 255, 0.35);
+  --text: #eef4ff;
+  --muted: #b9c7e9;
+  --accent: #62d4ff;
+  --accent-2: #80ffbf;
+  --warn: #ffd66b;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 12% 12%, rgba(98, 212, 255, 0.2), transparent 28%),
+    radial-gradient(circle at 88% 10%, rgba(128, 255, 191, 0.18), transparent 32%),
+    linear-gradient(165deg, var(--bg1), var(--bg2));
+}
+.page {
+  width: min(calc(100% - 28px), 1050px);
+  margin: 22px auto 34px;
+  padding: 26px;
+  border: 1px solid rgba(167, 193, 255, 0.25);
+  border-radius: 24px;
+  background: rgba(8, 12, 24, 0.62);
+  backdrop-filter: blur(6px);
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+.hero {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 20px;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel);
+  padding: 18px;
+}
+.player-head {
+  width: 120px;
+  image-rendering: pixelated;
+  border-radius: 10px;
+  border: 2px solid rgba(98, 212, 255, 0.7);
+  background: rgba(0, 0, 0, 0.3);
+}
+.head-placeholder {
+  width: 120px;
+  height: 120px;
+  display: grid;
+  place-items: center;
+  font-size: 0.76rem;
+  text-align: center;
+  line-height: 1.4;
+  border-radius: 10px;
+  border: 2px dashed rgba(255, 214, 107, 0.8);
+  color: var(--warn);
+  background: rgba(0, 0, 0, 0.25);
+  padding: 10px;
+}
+.name {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+.tagline {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+.grid {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 14px;
+}
+.card {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px;
+  background: var(--panel);
+}
+.card h2 {
+  margin: 0 0 10px;
+  font-size: 1.1rem;
+  color: var(--accent);
+}
+.meta-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+.meta-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  border-bottom: 1px solid rgba(185, 199, 233, 0.22);
+  padding-bottom: 6px;
+}
+.label { color: var(--muted); }
+.value { font-weight: 700; min-width: 80px; text-align: right; }
+.blank { opacity: 0.82; font-weight: 600; }
+.col-4 { grid-column: span 4; }
+.col-8 { grid-column: span 8; }
+.col-6 { grid-column: span 6; }
+.col-12 { grid-column: span 12; }
+.note {
+  color: var(--muted);
+  margin: 0;
+  line-height: 1.65;
+}
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.chip {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(121, 165, 255, 0.38);
+  color: var(--muted);
+  font-size: 0.9rem;
+  background: rgba(121, 165, 255, 0.14);
+}
+.footnote {
+  margin-top: 16px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+@media (max-width: 860px) {
+  .hero { grid-template-columns: 1fr; text-align: center; }
+  .player-head, .head-placeholder { margin-inline: auto; }
+  .col-4, .col-6, .col-8 { grid-column: span 12; }
+}

--- a/profiles/t0w0fu.html
+++ b/profiles/t0w0fu.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>t0w0fu | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/t0w0fu.png" alt="t0w0fu Minecraft player head" />
+      <div>
+        <h1 class="name">t0w0fu</h1>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">________________</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">________________</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">________________</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">________________</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">________________</span></li>
+          <li><span class="label">Signature Tool/Item</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank">____________________________________________________________</p>
+        <p class="note blank">____________________________________________________________</p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds & Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">________________</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">________________</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">________________</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">________________</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">________________</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+          <span class="chip">Builder</span>
+          <span class="chip">Explorer</span>
+          <span class="chip">Redstone</span>
+          <span class="chip">Farmer</span>
+          <span class="chip">PvE</span>
+          <span class="chip">Team Player</span>
+          <span class="chip">Event Host</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote">Tip: You can keep this page updated each season with milestones, favorite moments, and new achievements.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Make the members roster interactive by turning each player name into a clickable element that opens a dedicated profile page. 
- Provide a reusable, interesting profile template pre-filled with fields the team will populate later (First Joined, Seasons Played, Snapshot Stats, Recognition). 
- Use existing player head images from `assets/player_heads` when available and fall back to a placeholder so pages render before images are added.

### Description
- Updated `members.html` to replace plain list items with styled profile buttons linking to `profiles/<slug>.html` and added supporting CSS classes (`.member-list`, `.member-button`).
- Added a `profiles/` directory containing one generated HTML profile per member and a shared stylesheet `profiles/profile.css` that implements a hero/header, stat cards, builds/projects, community highlights, quick tags, and responsive layout.
- Each profile uses `../assets/player_heads/<name>.png` when a matching image exists, otherwise shows a non-invasive placeholder block; blank fields are left for `First Joined`, `Seasons Played`, `Playtime`, `Deaths`, and `Recognition` to be filled manually.
- Kept profile pages low-maintenance by adding fields and quick tags that are easy to update and do not frequently change.

### Testing
- Ran a link existence check script that scanned `members.html` for `profiles/` hrefs and confirmed there were no missing files and `profile_count` reported 26 generated profile pages (no missing links).
- Verified `profiles/profile.css` and the profile HTML files were created (script-driven generation) and that pages reference `../assets/player_heads/<name>.png` where those assets exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25a7754c4832fb6baeaa23ac31995)