### PR TITLE
Add live Minecraft server status badge next to site name

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,61 @@
 
     .brand span { font-size: 1rem; }
 
+    .brand-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      margin-left: 8px;
+      padding: 7px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(122, 162, 255, 0.35);
+      background: rgba(20, 34, 52, 0.74);
+      color: var(--muted);
+      font-size: 0.84rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      transition: box-shadow 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+      white-space: nowrap;
+    }
+
+    .brand-status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: #8f9ebf;
+      transition: background-color 0.25s ease;
+      flex-shrink: 0;
+    }
+
+    .brand-status.online {
+      color: #d9ffe8;
+      border-color: rgba(95, 255, 156, 0.55);
+    }
+
+    .brand-status.online .brand-status-dot {
+      background: var(--green);
+    }
+
+    .brand-status.offline {
+      color: #ffd9df;
+      border-color: rgba(255, 108, 143, 0.55);
+    }
+
+    .brand-status.offline .brand-status-dot {
+      background: var(--danger);
+    }
+
+    .brand-status.online:hover,
+    .brand-status.online:focus-visible {
+      box-shadow: 0 0 0 2px rgba(95, 255, 156, 0.2), 0 0 22px rgba(95, 255, 156, 0.48);
+    }
+
+    .brand-status.offline:hover,
+    .brand-status.offline:focus-visible {
+      box-shadow: 0 0 0 2px rgba(255, 108, 143, 0.2), 0 0 22px rgba(255, 108, 143, 0.45);
+    }
+
     .menu-toggle {
       display: none;
       align-items: center;
@@ -607,6 +662,12 @@
         letter-spacing: 0.06em;
       }
 
+      .brand-status {
+        margin-left: 0;
+        padding: 6px 10px;
+        font-size: 0.74rem;
+      }
+
       .brand-logo {
         width: 42px;
         height: 42px;
@@ -702,6 +763,10 @@
         <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
+      <span id="server-status-badge" class="brand-status" aria-live="polite">
+        <span class="brand-status-dot" aria-hidden="true"></span>
+        <span id="server-status-text">Checking…</span>
+      </span>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
 
       <nav id="mobile-nav" aria-label="Main navigation">
@@ -1022,6 +1087,43 @@
       document.addEventListener("keydown", (event) => {
         if (event.key === "Escape") closeMenu();
       });
+    })();
+
+    (() => {
+      const badge = document.getElementById("server-status-badge");
+      const label = document.getElementById("server-status-text");
+      const statusApi = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
+      if (!badge || !label) return;
+
+      const setOffline = () => {
+        badge.classList.remove("online");
+        badge.classList.add("offline");
+        label.textContent = "Offline";
+      };
+
+      const setOnline = (playersOnline) => {
+        badge.classList.remove("offline");
+        badge.classList.add("online");
+        label.textContent = `Online ${playersOnline}/20`;
+      };
+
+      const refreshServerStatus = async () => {
+        try {
+          const response = await fetch(statusApi, { cache: "no-store" });
+          if (!response.ok) throw new Error("Bad response");
+          const data = await response.json();
+          if (!data?.online) {
+            setOffline();
+            return;
+          }
+          setOnline(Number(data.players?.online ?? 0));
+        } catch (error) {
+          setOffline();
+        }
+      };
+
+      refreshServerStatus();
+      window.setInterval(refreshServerStatus, 30_000);
     })();
 
     (() => {


### PR DESCRIPTION
## Summary
- added a status badge next to the Pinnacle SMP brand in the main header to mirror the requested visual style
- implemented online/offline states with dynamic label text (`Online x/20` or `Offline`)
- added hover glow effects: green when online, red when offline
- wired badge updates to poll `https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun` every 30 seconds
- included responsive sizing tweaks so the badge remains readable on smaller screens

## Details
- The badge initializes as `Checking…`, then updates after the first API response.
- If the API call fails or reports `online: false`, the badge falls back to `Offline`.
- Player count uses the API `players.online` value and formats it as `Online x/20`.

## Files changed
- `index.html`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2aeeaee80832fb8654cf149e8f099)