### PR TITLE
Add live server status badge to header with styling and periodic refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,13 @@
       min-height: 82px;
     }
 
+    .brand-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+
     .brand {
       display: flex;
       align-items: center;
@@ -132,6 +139,61 @@
     }
 
     .brand span { font-size: 1rem; }
+
+    .brand-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      margin-left: 8px;
+      padding: 7px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(122, 162, 255, 0.35);
+      background: rgba(20, 34, 52, 0.74);
+      color: var(--muted);
+      font-size: 0.84rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      transition: box-shadow 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+      white-space: nowrap;
+    }
+
+    .brand-status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: #8f9ebf;
+      transition: background-color 0.25s ease;
+      flex-shrink: 0;
+    }
+
+    .brand-status.online {
+      color: #d9ffe8;
+      border-color: rgba(95, 255, 156, 0.55);
+    }
+
+    .brand-status.online .brand-status-dot {
+      background: var(--green);
+    }
+
+    .brand-status.offline {
+      color: #ffd9df;
+      border-color: rgba(255, 108, 143, 0.55);
+    }
+
+    .brand-status.offline .brand-status-dot {
+      background: var(--danger);
+    }
+
+    .brand-status.online:hover,
+    .brand-status.online:focus-visible {
+      box-shadow: 0 0 0 2px rgba(95, 255, 156, 0.2), 0 0 22px rgba(95, 255, 156, 0.48);
+    }
+
+    .brand-status.offline:hover,
+    .brand-status.offline:focus-visible {
+      box-shadow: 0 0 0 2px rgba(255, 108, 143, 0.2), 0 0 22px rgba(255, 108, 143, 0.45);
+    }
 
     .menu-toggle {
       display: none;
@@ -597,14 +659,26 @@
         padding: 14px 0;
       }
 
-      .brand {
+      .brand-group {
         width: auto;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .brand {
         gap: 10px;
       }
 
       .brand span {
         font-size: 0.95rem;
         letter-spacing: 0.06em;
+      }
+
+      .brand-status {
+        margin-left: 0;
+        padding: 6px 10px;
+        font-size: 0.74rem;
       }
 
       .brand-logo {
@@ -698,10 +772,16 @@
 <body>
   <header class="site-header">
     <div class="container nav-wrap">
-      <a href="#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
-        <span>Pinnacle SMP</span>
-      </a>
+      <div class="brand-group">
+        <a href="#home" class="brand">
+          <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+          <span>Pinnacle SMP</span>
+        </a>
+        <span id="server-status-badge" class="brand-status" aria-live="polite">
+          <span class="brand-status-dot" aria-hidden="true"></span>
+          <span id="server-status-text">Checking…</span>
+        </span>
+      </div>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
 
       <nav id="mobile-nav" aria-label="Main navigation">
@@ -1022,6 +1102,43 @@
       document.addEventListener("keydown", (event) => {
         if (event.key === "Escape") closeMenu();
       });
+    })();
+
+    (() => {
+      const badge = document.getElementById("server-status-badge");
+      const label = document.getElementById("server-status-text");
+      const statusApi = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
+      if (!badge || !label) return;
+
+      const setOffline = () => {
+        badge.classList.remove("online");
+        badge.classList.add("offline");
+        label.textContent = "Offline";
+      };
+
+      const setOnline = (playersOnline) => {
+        badge.classList.remove("offline");
+        badge.classList.add("online");
+        label.textContent = `Online ${playersOnline}/20`;
+      };
+
+      const refreshServerStatus = async () => {
+        try {
+          const response = await fetch(statusApi, { cache: "no-store" });
+          if (!response.ok) throw new Error("Bad response");
+          const data = await response.json();
+          if (!data?.online) {
+            setOffline();
+            return;
+          }
+          setOnline(Number(data.players?.online ?? 0));
+        } catch (error) {
+          setOffline();
+        }
+      };
+
+      refreshServerStatus();
+      window.setInterval(refreshServerStatus, 30_000);
     })();
 
     (() => {


### PR DESCRIPTION
### Motivation
- Surface real-time server availability and player count in the site header so visitors can immediately see if the Minecraft server is online. 
- Provide a compact, accessible status indicator that fits the existing brand area and works responsively on mobile. 
- Keep the status up-to-date automatically by polling a public server status API.

### Description
- Added a `brand-group` wrapper and moved the brand link into it to accommodate a new status badge next to the logo. 
- Implemented a styled status badge with classes `brand-status`, `brand-status-dot`, and `online`/`offline` modifiers including hover/focus visual treatments and responsive sizing adjustments. 
- Injected a small self-invoking script that queries `https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun`, sets the badge to `Online N/20` or `Offline`, and refreshes every 30 seconds using `fetch` and `window.setInterval`. 
- Ensured accessibility attributes like `aria-live=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2aeeaee80832fb8654cf149e8f099)