### PR TITLE
Brighten site-wide gaming color palette

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -6,12 +6,12 @@
   <title>About Season 12 | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.3);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --cyan: #57d5ff;
-      --green: #5fff9c;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.42);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --cyan: #72e0ff;
+      --green: #7affb4;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -53,7 +53,7 @@
       width: min(calc(100% - 32px), 1100px);
       margin: 28px auto 52px;
       padding: 30px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);

--- a/about-us.html
+++ b/about-us.html
@@ -6,13 +6,13 @@
   <title>About Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.8);
-      --line: rgba(156, 191, 236, 0.3);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --cyan: #57d5ff;
-      --green: #5fff9c;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.84);
+      --line: rgba(168, 208, 255, 0.42);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --cyan: #72e0ff;
+      --green: #7affb4;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -53,7 +53,7 @@
       width: min(calc(100% - 32px), 1100px);
       margin: 0 auto;
       padding: 36px 0 54px;
-          background: rgba(15, 22, 36, 0.62);
+          background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);

--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -6,13 +6,13 @@
   <title>Ban Appeal | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.28);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.4);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -52,7 +52,7 @@
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(15, 22, 36, 0.62);
+          background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -72,7 +72,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(10, 14, 22, 0.94);
+      background: rgba(19, 30, 48, 0.94);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -92,7 +92,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
   </style>
 </head>
 <body>

--- a/contact-us.html
+++ b/contact-us.html
@@ -6,13 +6,13 @@
   <title>Contact Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.28);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.4);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -52,7 +52,7 @@
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -67,7 +67,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(10, 14, 22, 0.94);
+      background: rgba(19, 30, 48, 0.94);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
   </style>
 </head>
 <body>

--- a/faq.html
+++ b/faq.html
@@ -6,13 +6,13 @@
   <title>FAQs | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.28);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.4);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
       --radius: 20px;
       --max: 980px;
     }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -56,7 +56,7 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(15, 22, 36, 0.62);
+          background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -87,7 +87,7 @@
     }
 
     details {
-      background: rgba(10, 14, 22, 0.85);
+      background: rgba(19, 30, 48, 0.88);
       border: 1px solid rgba(122, 162, 255, 0.2);
       border-radius: 14px;
       padding: 14px 16px;
@@ -137,7 +137,7 @@
     }
 
     .btn-secondary {
-      background: rgba(122, 162, 255, 0.14);
+      background: rgba(141, 181, 255, 0.2);
       color: var(--text);
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
   <title>Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
+      --bg: #10172a;
       --bg-soft: #101521;
-      --panel: rgba(27, 38, 58, 0.84);
-      --panel-2: rgba(34, 46, 69, 0.88);
-      --line: rgba(160, 194, 235, 0.3);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
-      --blue: #7aa2ff;
-      --gold: #ffd66b;
+      --panel: rgba(40, 57, 88, 0.87);
+      --panel-2: rgba(48, 67, 102, 0.9);
+      --line: rgba(173, 214, 255, 0.42);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
+      --blue: #8db5ff;
+      --gold: #ffe082;
       --danger: #ff6c8f;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
@@ -32,7 +32,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -92,7 +92,7 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -104,7 +104,7 @@
       z-index: 50;
       backdrop-filter: blur(16px);
       background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(122, 162, 255, 0.12);
+      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
     }
 
     .nav-wrap {
@@ -147,7 +147,7 @@
       margin-left: 8px;
       padding: 7px 12px;
       border-radius: 999px;
-      border: 1px solid rgba(122, 162, 255, 0.35);
+      border: 1px solid rgba(141, 181, 255, 0.44);
       background: rgba(20, 34, 52, 0.74);
       color: var(--muted);
       font-size: 0.84rem;
@@ -203,8 +203,8 @@
       min-height: 40px;
       padding: 0 14px;
       border-radius: 12px;
-      border: 1px solid rgba(122, 162, 255, 0.26);
-      background: rgba(122, 162, 255, 0.14);
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: rgba(141, 181, 255, 0.2);
       color: var(--text);
       font-weight: 700;
       font: inherit;
@@ -239,7 +239,7 @@
 
     nav > ul > li > a:hover,
     nav > ul > li > a:focus {
-      background: rgba(122, 162, 255, 0.12);
+      background: rgba(141, 181, 255, 0.2);
       color: white;
       outline: none;
     }
@@ -281,7 +281,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(122, 162, 255, 0.12);
+      background: rgba(141, 181, 255, 0.2);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -483,7 +483,7 @@
       text-transform: uppercase;
       font-size: 0.8rem;
       color: #d6e2ff;
-      background: rgba(122, 162, 255, 0.1);
+      background: rgba(141, 181, 255, 0.16);
     }
 
     .events-table tbody tr:last-child td {
@@ -553,7 +553,7 @@
 
     .site-footer {
       margin-top: 48px;
-      border-top: 1px solid rgba(122, 162, 255, 0.12);
+      border-top: 1px solid rgba(141, 181, 255, 0.2);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/members.html
+++ b/members.html
@@ -6,14 +6,14 @@
   <title>Members | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.3);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --cyan: #57d5ff;
-      --green: #5fff9c;
-      --gold: #ffd66b;
-      --blue: #7aa2ff;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.42);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --cyan: #72e0ff;
+      --green: #7affb4;
+      --gold: #ffe082;
+      --blue: #8db5ff;
       --red: #ff6b6b;
       --purple: #c48dff;
     }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -56,7 +56,7 @@
       width: min(calc(100% - 32px), 1120px);
       margin: 0 auto;
       padding: 36px 0 54px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -100,7 +100,7 @@
       border: 1px solid rgba(156, 191, 236, 0.25);
       border-radius: 16px;
       padding: 18px;
-      background: rgba(11, 16, 28, 0.4);
+      background: rgba(24, 34, 54, 0.45);
     }
 
     .member-section h2 {
@@ -139,7 +139,7 @@
       align-items: center;
       width: 100%;
       border: 1px solid rgba(122, 162, 255, 0.34);
-      background: rgba(122, 162, 255, 0.1);
+      background: rgba(141, 181, 255, 0.16);
       color: var(--text);
       text-decoration: none;
       border-radius: 10px;
@@ -161,7 +161,7 @@
       border: 1px solid rgba(156, 191, 236, 0.25);
       border-radius: 16px;
       padding: 22px 18px;
-      background: rgba(11, 16, 28, 0.4);
+      background: rgba(24, 34, 54, 0.45);
       text-align: center;
     }
 
@@ -175,9 +175,9 @@
       width: min(100%, 520px);
       margin: 0 auto;
       border-radius: 14px;
-      border: 1px solid rgba(122, 162, 255, 0.35);
+      border: 1px solid rgba(141, 181, 255, 0.44);
       padding: 16px;
-      background: rgba(122, 162, 255, 0.1);
+      background: rgba(141, 181, 255, 0.16);
     }
 
     .award-highlight h3 {

--- a/news.html
+++ b/news.html
@@ -6,16 +6,16 @@
   <title>Pinnacle SMP • Server News</title>
   <style>
     :root {
-      --bg: #090b10;
+      --bg: #10172a;
       --bg-soft: #101521;
-      --panel: rgba(27, 38, 58, 0.84);
-      --line: rgba(160, 194, 235, 0.3);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
-      --blue: #7aa2ff;
-      --gold: #ffd66b;
+      --panel: rgba(40, 57, 88, 0.87);
+      --line: rgba(173, 214, 255, 0.42);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
+      --blue: #8db5ff;
+      --gold: #ffe082;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
       --max: 1040px;
@@ -30,7 +30,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -70,7 +70,7 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -82,7 +82,7 @@
       z-index: 50;
       backdrop-filter: blur(16px);
       background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(122, 162, 255, 0.12);
+      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
     }
 
     .nav-wrap {
@@ -139,7 +139,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(122, 162, 255, 0.12);
+      background: rgba(141, 181, 255, 0.2);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -239,7 +239,7 @@
 
     .site-footer {
       margin-top: 24px;
-      border-top: 1px solid rgba(122, 162, 255, 0.12);
+      border-top: 1px solid rgba(141, 181, 255, 0.2);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -6,13 +6,13 @@
   <title>Plugin Suggestions | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.28);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.4);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -52,7 +52,7 @@
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -67,7 +67,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(10, 14, 22, 0.94);
+      background: rgba(19, 30, 48, 0.94);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
   </style>
 </head>
 <body>

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -1,13 +1,13 @@
 :root {
-  --bg1: #0b1020;
-  --bg2: #151d33;
-  --panel: rgba(18, 25, 44, 0.88);
-  --line: rgba(121, 165, 255, 0.35);
-  --text: #eef4ff;
-  --muted: #b9c7e9;
-  --accent: #62d4ff;
-  --accent-2: #80ffbf;
-  --warn: #ffd66b;
+  --bg1: #13203a;
+  --bg2: #1e2e4d;
+  --panel: rgba(35, 49, 78, 0.9);
+  --line: rgba(150, 193, 255, 0.45);
+  --text: #f4f8ff;
+  --muted: #d1dcf6;
+  --accent: #74e2ff;
+  --accent-2: #95ffd0;
+  --warn: #ffe082;
 }
 * { box-sizing: border-box; }
 body {
@@ -26,7 +26,7 @@ body {
   padding: 26px;
   border: 1px solid rgba(167, 193, 255, 0.25);
   border-radius: 24px;
-  background: rgba(8, 12, 24, 0.62);
+  background: rgba(20, 30, 50, 0.68);
   backdrop-filter: blur(6px);
 }
 .back-link {

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -6,15 +6,15 @@
   <title>Tournament Standings | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --panel: rgba(24, 33, 52, 0.86);
-      --line: rgba(156, 191, 236, 0.35);
-      --gold: #ffd66b;
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --panel: rgba(38, 53, 82, 0.88);
+      --line: rgba(168, 208, 255, 0.45);
+      --gold: #ffe082;
       --silver: #dbe8ff;
       --bronze: #ffb27a;
-      --accent: #57d5ff;
-      --green: #5fff9c;
+      --accent: #72e0ff;
+      --green: #7affb4;
     }
 
     * { box-sizing: border-box; }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -135,7 +135,7 @@
     .fill {
       height: 100%;
       border-radius: inherit;
-      background: linear-gradient(90deg, #57d5ff 0%, #5fff9c 100%);
+      background: linear-gradient(90deg, #72e0ff 0%, #7affb4 100%);
     }
 
     .entry[data-rank="1"] {

--- a/vote-history.html
+++ b/vote-history.html
@@ -6,14 +6,14 @@
   <title>Vote History | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --line: rgba(156, 191, 236, 0.3);
-      --panel: rgba(24, 33, 52, 0.82);
-      --panel-strong: rgba(31, 42, 64, 0.9);
-      --cyan: #57d5ff;
-      --green: #5fff9c;
-      --gold: #ffd66b;
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --line: rgba(168, 208, 255, 0.42);
+      --panel: rgba(38, 53, 82, 0.86);
+      --panel-strong: rgba(44, 61, 92, 0.9);
+      --cyan: #72e0ff;
+      --green: #7affb4;
+      --gold: #ffe082;
       --pink: #ff8ec1;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
     }
@@ -27,7 +27,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -57,7 +57,7 @@
       width: min(calc(100% - 32px), 1220px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -200,7 +200,7 @@
       height: 9px;
       border-radius: 999px;
       overflow: hidden;
-      background: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.18);
     }
 
     .bar > i {

--- a/vote-links.html
+++ b/vote-links.html
@@ -6,13 +6,13 @@
   <title>Vote Links | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --line: rgba(156, 191, 236, 0.3);
-      --panel: rgba(24, 33, 52, 0.8);
-      --cyan: #57d5ff;
-      --green: #5fff9c;
-      --gold: #ffd66b;
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --line: rgba(168, 208, 255, 0.42);
+      --panel: rgba(38, 53, 82, 0.84);
+      --cyan: #72e0ff;
+      --green: #7affb4;
+      --gold: #ffe082;
       --violet: #b6a2ff;
     }
 
@@ -25,7 +25,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -55,7 +55,7 @@
       width: min(calc(100% - 32px), 1200px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -6,13 +6,13 @@
   <title>Whitelist Application | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #090b10;
-      --panel: rgba(24, 33, 52, 0.82);
-      --line: rgba(156, 191, 236, 0.28);
-      --text: #eef3ff;
-      --muted: #c2cdea;
-      --green: #5fff9c;
-      --cyan: #57d5ff;
+      --bg: #10172a;
+      --panel: rgba(38, 53, 82, 0.86);
+      --line: rgba(168, 208, 255, 0.4);
+      --text: #f4f8ff;
+      --muted: #d4def7;
+      --green: #7affb4;
+      --cyan: #72e0ff;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #0f1420;
+      background: #16223a;
     }
 
     body::before {
@@ -52,7 +52,7 @@
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(15, 22, 36, 0.62);
+      background: rgba(24, 36, 58, 0.68);
       border: 1px solid rgba(162, 196, 255, 0.2);
       border-radius: 26px;
       backdrop-filter: blur(8px);
@@ -72,7 +72,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(10, 14, 22, 0.94);
+      background: rgba(19, 30, 48, 0.94);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -107,7 +107,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(122, 162, 255, 0.14); color: var(--text); }
+    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Make the site feel brighter and more inviting while retaining a gaming-focused neon/cyan-green accent palette. 
- Improve readability and contrast for content panels, borders and form controls without changing layout or copy. 
- Keep visual consistency between core pages and profile pages by aligning profile CSS tokens with the global theme.

### Description
- Updated theme CSS variables across primary pages (home, members, news, about/season pages, voting pages, form pages, plugin/ban/contact pages) to a brighter palette (base background moved to `#16223a`, base root `--bg` to `#10172a`).
- Increased panel and backdrop luminance by adjusting panel RGBA values to `rgba(38, 53, 82, ...)` / `rgba(40, 57, 88, ...)`, and boosted border/line contrast via lighter `rgba(...)` values. 
- Brightened text/muted/accents: `--text` to `#f4f8ff`, `--muted` to `#d4def7`, `--cyan` to `#72e0ff`, `--green` to `#7affb4`, `--blue`/`--gold` variants updated, and updated gradients (including tournament fill) to match the new accents. 
- Tuned UI control backgrounds and secondary button tones (form input backgrounds, `.btn-secondary`, nav/menu hover backgrounds) and updated `profiles/profile.css` variables so profile pages match the new site tone.

### Testing
- Ran the scripted search-and-replace and recorded the list of affected files to ensure the replacement applied across the intended pages. 
- Verified the new tokens are present with `rg` searches for `#10172a`, `#16223a`, `#7affb4`, `#72e0ff`, and `#d4def7`, which returned the updated pages. 
- Inspected the post-change summary to confirm only color/theme tokens and related RGBA values were adjusted (no layout or content changes); automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e442db9118832f8a5bdf1e9814071d)