### PR TITLE
Refresh site color theme to new purple/pink/orange brand

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -6,12 +6,12 @@
   <title>About Season 12 | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --cyan: #72e0ff;
-      --green: #7affb4;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.55);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --cyan: #FB773C;
+      --green: #EB3678;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 28px auto 52px;
       padding: 30px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/about-us.html
+++ b/about-us.html
@@ -6,13 +6,13 @@
   <title>About Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.84);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --cyan: #72e0ff;
-      --green: #7affb4;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.86);
+      --line: rgba(251, 119, 60, 0.55);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --cyan: #FB773C;
+      --green: #EB3678;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 0 auto;
       padding: 36px 0 54px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -6,13 +6,13 @@
   <title>Ban Appeal | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.5);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -92,7 +92,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/contact-us.html
+++ b/contact-us.html
@@ -6,13 +6,13 @@
   <title>Contact Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.5);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/faq.html
+++ b/faq.html
@@ -6,13 +6,13 @@
   <title>FAQs | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.5);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
       --radius: 20px;
       --max: 980px;
     }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -47,17 +47,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -137,7 +137,7 @@
     }
 
     .btn-secondary {
-      background: rgba(141, 181, 255, 0.2);
+      background: rgba(251, 119, 60, 0.4);
       color: var(--text);
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -6,18 +6,18 @@
   <title>Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --bg-soft: #101521;
-      --panel: rgba(40, 57, 88, 0.87);
-      --panel-2: rgba(48, 67, 102, 0.9);
-      --line: rgba(173, 214, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
-      --blue: #8db5ff;
-      --gold: #ffe082;
-      --danger: #ff6c8f;
+      --bg: #180161;
+      --bg-soft: #4F1787;
+      --panel: rgba(79, 23, 135, 0.88);
+      --panel-2: rgba(235, 54, 120, 0.86);
+      --line: rgba(251, 119, 60, 0.55);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
+      --blue: #FB773C;
+      --gold: #FB773C;
+      --danger: #EB3678;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
       --max: 1240px;
@@ -32,7 +32,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -53,9 +53,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     a {
@@ -92,8 +92,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -103,8 +103,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border-bottom: 1px solid rgba(251, 119, 60, 0.4);
     }
 
     .nav-wrap {
@@ -147,8 +147,8 @@
       margin-left: 8px;
       padding: 7px 12px;
       border-radius: 999px;
-      border: 1px solid rgba(141, 181, 255, 0.44);
-      background: rgba(20, 34, 52, 0.74);
+      border: 1px solid rgba(251, 119, 60, 0.62);
+      background: rgba(79, 23, 135, 0.86);
       color: var(--muted);
       font-size: 0.84rem;
       font-weight: 700;
@@ -162,14 +162,14 @@
       width: 10px;
       height: 10px;
       border-radius: 999px;
-      background: #8f9ebf;
+      background: #180161;
       transition: background-color 0.25s ease;
       flex-shrink: 0;
     }
 
     .brand-status.online {
-      color: #d9ffe8;
-      border-color: rgba(95, 255, 156, 0.55);
+      color: #FDF2FF;
+      border-color: rgba(251, 119, 60, 0.78);
     }
 
     .brand-status.online .brand-status-dot {
@@ -177,8 +177,8 @@
     }
 
     .brand-status.offline {
-      color: #ffd9df;
-      border-color: rgba(255, 108, 143, 0.55);
+      color: #FDF2FF;
+      border-color: rgba(251, 119, 60, 0.72);
     }
 
     .brand-status.offline .brand-status-dot {
@@ -187,12 +187,12 @@
 
     .brand-status.online:hover,
     .brand-status.online:focus-visible {
-      box-shadow: 0 0 0 2px rgba(95, 255, 156, 0.2), 0 0 22px rgba(95, 255, 156, 0.48);
+      box-shadow: 0 0 0 2px rgba(251, 119, 60, 0.24), 0 0 22px rgba(251, 119, 60, 0.48);
     }
 
     .brand-status.offline:hover,
     .brand-status.offline:focus-visible {
-      box-shadow: 0 0 0 2px rgba(255, 108, 143, 0.2), 0 0 22px rgba(255, 108, 143, 0.45);
+      box-shadow: 0 0 0 2px rgba(251, 119, 60, 0.24), 0 0 22px rgba(251, 119, 60, 0.44);
     }
 
     .menu-toggle {
@@ -203,8 +203,8 @@
       min-height: 40px;
       padding: 0 14px;
       border-radius: 12px;
-      border: 1px solid rgba(141, 181, 255, 0.34);
-      background: rgba(141, 181, 255, 0.2);
+      border: 1px solid rgba(251, 119, 60, 0.52);
+      background: rgba(251, 119, 60, 0.4);
       color: var(--text);
       font-weight: 700;
       font: inherit;
@@ -239,7 +239,7 @@
 
     nav > ul > li > a:hover,
     nav > ul > li > a:focus {
-      background: rgba(141, 181, 255, 0.2);
+      background: rgba(251, 119, 60, 0.4);
       color: white;
       outline: none;
     }
@@ -281,7 +281,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(141, 181, 255, 0.2);
+      background: rgba(251, 119, 60, 0.4);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -368,7 +368,7 @@
     .hover-lift:hover,
     .hover-lift:focus-within {
       transform: translateY(-6px);
-      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(122, 162, 255, 0.18);
+      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(251, 119, 60, 0.44);
       border-color: rgba(122, 162, 255, 0.45);
     }
 
@@ -394,17 +394,21 @@
 
     .server-card {
       background: var(--panel-2);
-      border: 1px solid rgba(95,255,156,0.16);
+      border: 1px solid rgba(251, 119, 60, 0.55);
       border-radius: 18px;
       padding: 18px;
     }
 
     .server-ip {
       margin-top: 6px;
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 10px;
       font-size: 1.15rem;
       font-weight: 800;
       letter-spacing: 0.04em;
-      color: var(--green);
+      color: #180161;
+      background: #FB773C;
     }
 
     .status-grid {
@@ -483,7 +487,7 @@
       text-transform: uppercase;
       font-size: 0.8rem;
       color: #d6e2ff;
-      background: rgba(141, 181, 255, 0.16);
+      background: rgba(235, 54, 120, 0.22);
     }
 
     .events-table tbody tr:last-child td {
@@ -514,7 +518,7 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(255, 214, 107, 0.1);
+      background: rgba(235, 54, 120, 0.22);
       color: var(--gold);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
@@ -553,7 +557,7 @@
 
     .site-footer {
       margin-top: 48px;
-      border-top: 1px solid rgba(141, 181, 255, 0.2);
+      border-top: 1px solid rgba(251, 119, 60, 0.4);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/members.html
+++ b/members.html
@@ -6,16 +6,16 @@
   <title>Members | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --cyan: #72e0ff;
-      --green: #7affb4;
-      --gold: #ffe082;
-      --blue: #8db5ff;
-      --red: #ff6b6b;
-      --purple: #c48dff;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.55);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --cyan: #FB773C;
+      --green: #EB3678;
+      --gold: #FB773C;
+      --blue: #FB773C;
+      --red: #EB3678;
+      --purple: #FB773C;
     }
 
     * { box-sizing: border-box; }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -47,17 +47,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1120px);
       margin: 0 auto;
       padding: 36px 0 54px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -97,7 +97,7 @@
     }
 
     .member-section {
-      border: 1px solid rgba(156, 191, 236, 0.25);
+      border: 1px solid rgba(251, 119, 60, 0.46);
       border-radius: 16px;
       padding: 18px;
       background: rgba(24, 34, 54, 0.45);
@@ -139,7 +139,7 @@
       align-items: center;
       width: 100%;
       border: 1px solid rgba(122, 162, 255, 0.34);
-      background: rgba(141, 181, 255, 0.16);
+      background: rgba(235, 54, 120, 0.22);
       color: var(--text);
       text-decoration: none;
       border-radius: 10px;
@@ -158,7 +158,7 @@
 
     .awards-panel {
       margin-top: 22px;
-      border: 1px solid rgba(156, 191, 236, 0.25);
+      border: 1px solid rgba(251, 119, 60, 0.46);
       border-radius: 16px;
       padding: 22px 18px;
       background: rgba(24, 34, 54, 0.45);
@@ -175,9 +175,9 @@
       width: min(100%, 520px);
       margin: 0 auto;
       border-radius: 14px;
-      border: 1px solid rgba(141, 181, 255, 0.44);
+      border: 1px solid rgba(251, 119, 60, 0.62);
       padding: 16px;
-      background: rgba(141, 181, 255, 0.16);
+      background: rgba(235, 54, 120, 0.22);
     }
 
     .award-highlight h3 {

--- a/news.html
+++ b/news.html
@@ -6,16 +6,16 @@
   <title>Pinnacle SMP • Server News</title>
   <style>
     :root {
-      --bg: #10172a;
-      --bg-soft: #101521;
-      --panel: rgba(40, 57, 88, 0.87);
-      --line: rgba(173, 214, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
-      --blue: #8db5ff;
-      --gold: #ffe082;
+      --bg: #180161;
+      --bg-soft: #4F1787;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.55);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
+      --blue: #FB773C;
+      --gold: #FB773C;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
       --max: 1040px;
@@ -30,7 +30,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -51,9 +51,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     a { color: inherit; text-decoration: none; }
@@ -70,8 +70,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -81,8 +81,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border-bottom: 1px solid rgba(251, 119, 60, 0.4);
     }
 
     .nav-wrap {
@@ -126,7 +126,7 @@
 
     .btn:hover {
       transform: translateY(-2px);
-      border-color: rgba(95,255,156,0.42);
+      border-color: rgba(176,219,156,0.62);
     }
 
     .hero {
@@ -139,7 +139,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(141, 181, 255, 0.2);
+      background: rgba(251, 119, 60, 0.4);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -189,7 +189,7 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(255, 214, 107, 0.1);
+      background: rgba(235, 54, 120, 0.22);
       color: var(--gold);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
@@ -208,7 +208,7 @@
       object-fit: cover;
       border-top: 1px solid var(--line);
       border-bottom: 1px solid var(--line);
-      background: linear-gradient(145deg, rgba(95,255,156,0.16), rgba(87,213,255,0.1));
+      background: linear-gradient(145deg, rgba(202,232,189,0.5), rgba(176,219,156,0.38));
     }
 
     .article-content {
@@ -231,15 +231,15 @@
       margin-top: 24px;
       padding: 14px 16px;
       border-radius: 14px;
-      border: 1px solid rgba(95,255,156,0.2);
-      background: rgba(95,255,156,0.06);
-      color: #d6ffe8;
+      border: 1px solid rgba(251, 119, 60, 0.55);
+      background: rgba(79, 23, 135, 0.74);
+      color: #FDF2FF;
       font-size: 0.95rem;
     }
 
     .site-footer {
       margin-top: 24px;
-      border-top: 1px solid rgba(141, 181, 255, 0.2);
+      border-top: 1px solid rgba(251, 119, 60, 0.4);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -6,13 +6,13 @@
   <title>Plugin Suggestions | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.5);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -1,13 +1,13 @@
 :root {
-  --bg1: #13203a;
-  --bg2: #1e2e4d;
-  --panel: rgba(35, 49, 78, 0.9);
-  --line: rgba(150, 193, 255, 0.45);
-  --text: #f4f8ff;
-  --muted: #d1dcf6;
-  --accent: #74e2ff;
-  --accent-2: #95ffd0;
-  --warn: #ffe082;
+  --bg1: #180161;
+  --bg2: #4F1787;
+  --panel: rgba(79, 23, 135, 0.88);
+  --line: rgba(251, 119, 60, 0.52);
+  --text: #FDF2FF;
+  --muted: #F3B6DA;
+  --accent: #FB773C;
+  --accent-2: #4F1787;
+  --warn: #FB773C;
 }
 * { box-sizing: border-box; }
 body {
@@ -16,17 +16,17 @@ body {
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at 12% 12%, rgba(98, 212, 255, 0.2), transparent 28%),
-    radial-gradient(circle at 88% 10%, rgba(128, 255, 191, 0.18), transparent 32%),
+    radial-gradient(circle at 12% 12%, rgba(235, 54, 120, 0.28), transparent 28%),
+    radial-gradient(circle at 88% 10%, rgba(251, 119, 60, 0.24), transparent 32%),
     linear-gradient(165deg, var(--bg1), var(--bg2));
 }
 .page {
   width: min(calc(100% - 28px), 1050px);
   margin: 22px auto 34px;
   padding: 26px;
-  border: 1px solid rgba(167, 193, 255, 0.25);
+  border: 1px solid rgba(251, 119, 60, 0.44);
   border-radius: 24px;
-  background: rgba(20, 30, 50, 0.68);
+  background: rgba(79, 23, 135, 0.82);
   backdrop-filter: blur(6px);
 }
 .back-link {
@@ -52,7 +52,7 @@ body {
   width: 120px;
   image-rendering: pixelated;
   border-radius: 10px;
-  border: 2px solid rgba(98, 212, 255, 0.7);
+  border: 2px solid rgba(24, 1, 97, 0.9);
   background: rgba(0, 0, 0, 0.3);
 }
 .head-placeholder {
@@ -64,7 +64,7 @@ body {
   text-align: center;
   line-height: 1.4;
   border-radius: 10px;
-  border: 2px dashed rgba(255, 214, 107, 0.8);
+  border: 2px dashed rgba(251, 119, 60, 0.76);
   color: var(--warn);
   background: rgba(0, 0, 0, 0.25);
   padding: 10px;
@@ -105,7 +105,7 @@ body {
   display: flex;
   justify-content: space-between;
   gap: 14px;
-  border-bottom: 1px solid rgba(185, 199, 233, 0.22);
+  border-bottom: 1px solid rgba(251, 119, 60, 0.4);
   padding-bottom: 6px;
 }
 .label { color: var(--muted); }
@@ -128,10 +128,10 @@ body {
 .chip {
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(121, 165, 255, 0.38);
+  border: 1px solid rgba(251, 119, 60, 0.52);
   color: var(--muted);
   font-size: 0.9rem;
-  background: rgba(121, 165, 255, 0.14);
+  background: rgba(235, 54, 120, 0.25);
 }
 .footnote {
   margin-top: 16px;

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -6,15 +6,15 @@
   <title>Tournament Standings | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --panel: rgba(38, 53, 82, 0.88);
-      --line: rgba(168, 208, 255, 0.45);
-      --gold: #ffe082;
-      --silver: #dbe8ff;
-      --bronze: #ffb27a;
-      --accent: #72e0ff;
-      --green: #7affb4;
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.55);
+      --gold: #FB773C;
+      --silver: #4F1787;
+      --bronze: #180161;
+      --accent: #FB773C;
+      --green: #EB3678;
     }
 
     * { box-sizing: border-box; }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -47,9 +47,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(11, 16, 24, 0.9) 100%);
     }
 
     .container {
@@ -96,7 +96,7 @@
     }
 
     .entry {
-      border: 1px solid rgba(156, 191, 236, 0.24);
+      border: 1px solid rgba(251, 119, 60, 0.44);
       border-radius: 14px;
       padding: 12px 14px;
       background: rgba(11, 16, 24, 0.68);
@@ -135,12 +135,12 @@
     .fill {
       height: 100%;
       border-radius: inherit;
-      background: linear-gradient(90deg, #72e0ff 0%, #7affb4 100%);
+      background: linear-gradient(90deg, #FB773C 0%, #EB3678 100%);
     }
 
     .entry[data-rank="1"] {
-      border-color: rgba(255, 214, 107, 0.6);
-      box-shadow: 0 0 0 1px rgba(255, 214, 107, 0.25) inset;
+      border-color: rgba(251, 119, 60, 0.7);
+      box-shadow: 0 0 0 1px rgba(251, 119, 60, 0.4) inset;
     }
 
     .entry[data-rank="2"] {

--- a/vote-history.html
+++ b/vote-history.html
@@ -6,15 +6,15 @@
   <title>Vote History | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --line: rgba(168, 208, 255, 0.42);
-      --panel: rgba(38, 53, 82, 0.86);
-      --panel-strong: rgba(44, 61, 92, 0.9);
-      --cyan: #72e0ff;
-      --green: #7affb4;
-      --gold: #ffe082;
-      --pink: #ff8ec1;
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --line: rgba(251, 119, 60, 0.55);
+      --panel: rgba(79, 23, 135, 0.88);
+      --panel-strong: rgba(79, 23, 135, 0.9);
+      --cyan: #FB773C;
+      --green: #EB3678;
+      --gold: #FB773C;
+      --pink: #FB773C;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
     }
 
@@ -27,7 +27,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -48,17 +48,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1220px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/vote-links.html
+++ b/vote-links.html
@@ -6,14 +6,14 @@
   <title>Vote Links | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --line: rgba(168, 208, 255, 0.42);
-      --panel: rgba(38, 53, 82, 0.84);
-      --cyan: #72e0ff;
-      --green: #7affb4;
-      --gold: #ffe082;
-      --violet: #b6a2ff;
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --line: rgba(251, 119, 60, 0.55);
+      --panel: rgba(79, 23, 135, 0.86);
+      --cyan: #FB773C;
+      --green: #EB3678;
+      --gold: #FB773C;
+      --violet: #FB773C;
     }
 
     * { box-sizing: border-box; }
@@ -25,7 +25,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -46,17 +46,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1200px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -94,7 +94,7 @@
       content: "";
       position: absolute;
       inset: 10% 2% 8%;
-      background: radial-gradient(circle, rgba(95,255,156,0.09), transparent 65%);
+      background: radial-gradient(circle, rgba(202,232,189,0.3), transparent 65%);
       z-index: -1;
       filter: blur(8px);
     }

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -6,13 +6,13 @@
   <title>Whitelist Application | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --green: #7affb4;
-      --cyan: #72e0ff;
+      --bg: #180161;
+      --panel: rgba(79, 23, 135, 0.88);
+      --line: rgba(251, 119, 60, 0.5);
+      --text: #FDF2FF;
+      --muted: #F3B6DA;
+      --green: #EB3678;
+      --cyan: #FB773C;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: #180161;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: rgba(79, 23, 135, 0.84);
+      border: 1px solid rgba(251, 119, 60, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -107,7 +107,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation

- Replace the previous blue/cyan theme with the new purple / pink / orange brand palette to align site visuals with updated branding. 
- Unify color tokens across pages and components so panels, gradients, borders, buttons, and highlights use the updated palette.

### Description

- Updated CSS variables and color usages across multiple HTML and CSS files (including `index.html`, `about-us.html`, `faq.html`, `news.html`, `members.html`, `profiles/profile.css`, and various forms/pages) to the new palette (`--bg`, `--panel`, `--line`, `--text`, `--muted`, `--cyan`, `--green`, etc.).
- Replaced background radial/linear gradients and adjusted `body::before`/`body::after` overlays to match the new accents and improved contrast. 
- Adjusted component styles such as `.container` backgrounds and borders, `.btn-secondary` colors, `.brand-status` borders/shadows, `.events-table` header background, `.server-ip` badge, and other tokenized color uses to the new hues. 
- Small layout/visual tweaks accompanying the palette change (e.g., border radii and shadow color updates retained but recolored to fit the new theme).

### Testing

- No unit tests were added or changed for this visual/theme update. 
- Performed a local static build and basic HTML/CSS validation to ensure pages render and styles parse without syntax errors (local checks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4489c1160832fae8d4650877704d5)