### PR TITLE
Update site theme to new four-color palette (#F4F0E4, #44A194, #537D96, #EC8F8D)

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -6,12 +6,12 @@
   <title>About Season 12 | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.55);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --cyan: #FB773C;
-      --green: #EB3678;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.55);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --cyan: #44A194;
+      --green: #EC8F8D;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 28px auto 52px;
       padding: 30px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/about-us.html
+++ b/about-us.html
@@ -6,13 +6,13 @@
   <title>About Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.86);
-      --line: rgba(251, 119, 60, 0.55);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --cyan: #FB773C;
-      --green: #EB3678;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.86);
+      --line: rgba(68, 161, 148, 0.55);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --cyan: #44A194;
+      --green: #EC8F8D;
     }
 
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 0 auto;
       padding: 36px 0 54px;
-          background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+          background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -6,13 +6,13 @@
   <title>Ban Appeal | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.5);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.5);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+          background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -92,7 +92,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
+    .btn-secondary { background: rgba(68, 161, 148, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/contact-us.html
+++ b/contact-us.html
@@ -6,13 +6,13 @@
   <title>Contact Us | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.5);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.5);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
+    .btn-secondary { background: rgba(68, 161, 148, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/faq.html
+++ b/faq.html
@@ -6,13 +6,13 @@
   <title>FAQs | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.5);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.5);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
       --radius: 20px;
       --max: 980px;
     }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -47,17 +47,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+          background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -137,7 +137,7 @@
     }
 
     .btn-secondary {
-      background: rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.4);
       color: var(--text);
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -6,18 +6,18 @@
   <title>Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --bg-soft: #4F1787;
-      --panel: rgba(79, 23, 135, 0.88);
-      --panel-2: rgba(235, 54, 120, 0.86);
-      --line: rgba(251, 119, 60, 0.55);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
-      --blue: #FB773C;
-      --gold: #FB773C;
-      --danger: #EB3678;
+      --bg: #537D96;
+      --bg-soft: #44A194;
+      --panel: rgba(68, 161, 148, 0.88);
+      --panel-2: rgba(236, 143, 141, 0.86);
+      --line: rgba(68, 161, 148, 0.55);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
+      --blue: #44A194;
+      --gold: #44A194;
+      --danger: #EC8F8D;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
       --max: 1240px;
@@ -32,7 +32,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -53,9 +53,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     a {
@@ -92,8 +92,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -103,8 +103,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(79, 23, 135, 0.84);
-      border-bottom: 1px solid rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.84);
+      border-bottom: 1px solid rgba(68, 161, 148, 0.4);
     }
 
     .nav-wrap {
@@ -147,8 +147,8 @@
       margin-left: 8px;
       padding: 7px 12px;
       border-radius: 999px;
-      border: 1px solid rgba(251, 119, 60, 0.62);
-      background: rgba(79, 23, 135, 0.86);
+      border: 1px solid rgba(68, 161, 148, 0.62);
+      background: rgba(68, 161, 148, 0.86);
       color: var(--muted);
       font-size: 0.84rem;
       font-weight: 700;
@@ -162,14 +162,14 @@
       width: 10px;
       height: 10px;
       border-radius: 999px;
-      background: #180161;
+      background: #537D96;
       transition: background-color 0.25s ease;
       flex-shrink: 0;
     }
 
     .brand-status.online {
-      color: #FDF2FF;
-      border-color: rgba(251, 119, 60, 0.78);
+      color: #F4F0E4;
+      border-color: rgba(68, 161, 148, 0.78);
     }
 
     .brand-status.online .brand-status-dot {
@@ -177,8 +177,8 @@
     }
 
     .brand-status.offline {
-      color: #FDF2FF;
-      border-color: rgba(251, 119, 60, 0.72);
+      color: #F4F0E4;
+      border-color: rgba(68, 161, 148, 0.72);
     }
 
     .brand-status.offline .brand-status-dot {
@@ -187,12 +187,12 @@
 
     .brand-status.online:hover,
     .brand-status.online:focus-visible {
-      box-shadow: 0 0 0 2px rgba(251, 119, 60, 0.24), 0 0 22px rgba(251, 119, 60, 0.48);
+      box-shadow: 0 0 0 2px rgba(68, 161, 148, 0.24), 0 0 22px rgba(68, 161, 148, 0.48);
     }
 
     .brand-status.offline:hover,
     .brand-status.offline:focus-visible {
-      box-shadow: 0 0 0 2px rgba(251, 119, 60, 0.24), 0 0 22px rgba(251, 119, 60, 0.44);
+      box-shadow: 0 0 0 2px rgba(68, 161, 148, 0.24), 0 0 22px rgba(68, 161, 148, 0.44);
     }
 
     .menu-toggle {
@@ -203,8 +203,8 @@
       min-height: 40px;
       padding: 0 14px;
       border-radius: 12px;
-      border: 1px solid rgba(251, 119, 60, 0.52);
-      background: rgba(251, 119, 60, 0.4);
+      border: 1px solid rgba(68, 161, 148, 0.52);
+      background: rgba(68, 161, 148, 0.4);
       color: var(--text);
       font-weight: 700;
       font: inherit;
@@ -239,7 +239,7 @@
 
     nav > ul > li > a:hover,
     nav > ul > li > a:focus {
-      background: rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.4);
       color: white;
       outline: none;
     }
@@ -281,7 +281,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.4);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -368,7 +368,7 @@
     .hover-lift:hover,
     .hover-lift:focus-within {
       transform: translateY(-6px);
-      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(251, 119, 60, 0.44);
+      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(68, 161, 148, 0.44);
       border-color: rgba(122, 162, 255, 0.45);
     }
 
@@ -394,7 +394,7 @@
 
     .server-card {
       background: var(--panel-2);
-      border: 1px solid rgba(251, 119, 60, 0.55);
+      border: 1px solid rgba(68, 161, 148, 0.55);
       border-radius: 18px;
       padding: 18px;
     }
@@ -407,8 +407,8 @@
       font-size: 1.15rem;
       font-weight: 800;
       letter-spacing: 0.04em;
-      color: #180161;
-      background: #FB773C;
+      color: #537D96;
+      background: #44A194;
     }
 
     .status-grid {
@@ -487,7 +487,7 @@
       text-transform: uppercase;
       font-size: 0.8rem;
       color: #d6e2ff;
-      background: rgba(235, 54, 120, 0.22);
+      background: rgba(236, 143, 141, 0.22);
     }
 
     .events-table tbody tr:last-child td {
@@ -518,7 +518,7 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(235, 54, 120, 0.22);
+      background: rgba(236, 143, 141, 0.22);
       color: var(--gold);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
@@ -557,7 +557,7 @@
 
     .site-footer {
       margin-top: 48px;
-      border-top: 1px solid rgba(251, 119, 60, 0.4);
+      border-top: 1px solid rgba(68, 161, 148, 0.4);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/members.html
+++ b/members.html
@@ -6,16 +6,16 @@
   <title>Members | Pinnacle SMP</title>
   <style>
     :root {
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.55);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --cyan: #FB773C;
-      --green: #EB3678;
-      --gold: #FB773C;
-      --blue: #FB773C;
-      --red: #EB3678;
-      --purple: #FB773C;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.55);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --cyan: #44A194;
+      --green: #EC8F8D;
+      --gold: #44A194;
+      --blue: #44A194;
+      --red: #EC8F8D;
+      --purple: #44A194;
     }
 
     * { box-sizing: border-box; }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -47,17 +47,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1120px);
       margin: 0 auto;
       padding: 36px 0 54px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -97,7 +97,7 @@
     }
 
     .member-section {
-      border: 1px solid rgba(251, 119, 60, 0.46);
+      border: 1px solid rgba(68, 161, 148, 0.46);
       border-radius: 16px;
       padding: 18px;
       background: rgba(24, 34, 54, 0.45);
@@ -139,7 +139,7 @@
       align-items: center;
       width: 100%;
       border: 1px solid rgba(122, 162, 255, 0.34);
-      background: rgba(235, 54, 120, 0.22);
+      background: rgba(236, 143, 141, 0.22);
       color: var(--text);
       text-decoration: none;
       border-radius: 10px;
@@ -158,7 +158,7 @@
 
     .awards-panel {
       margin-top: 22px;
-      border: 1px solid rgba(251, 119, 60, 0.46);
+      border: 1px solid rgba(68, 161, 148, 0.46);
       border-radius: 16px;
       padding: 22px 18px;
       background: rgba(24, 34, 54, 0.45);
@@ -175,9 +175,9 @@
       width: min(100%, 520px);
       margin: 0 auto;
       border-radius: 14px;
-      border: 1px solid rgba(251, 119, 60, 0.62);
+      border: 1px solid rgba(68, 161, 148, 0.62);
       padding: 16px;
-      background: rgba(235, 54, 120, 0.22);
+      background: rgba(236, 143, 141, 0.22);
     }
 
     .award-highlight h3 {

--- a/news.html
+++ b/news.html
@@ -6,16 +6,16 @@
   <title>Pinnacle SMP • Server News</title>
   <style>
     :root {
-      --bg: #180161;
-      --bg-soft: #4F1787;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.55);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
-      --blue: #FB773C;
-      --gold: #FB773C;
+      --bg: #537D96;
+      --bg-soft: #44A194;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.55);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
+      --blue: #44A194;
+      --gold: #44A194;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
       --radius: 22px;
       --max: 1040px;
@@ -30,7 +30,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -51,9 +51,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     a { color: inherit; text-decoration: none; }
@@ -70,8 +70,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -81,8 +81,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(79, 23, 135, 0.84);
-      border-bottom: 1px solid rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.84);
+      border-bottom: 1px solid rgba(68, 161, 148, 0.4);
     }
 
     .nav-wrap {
@@ -139,7 +139,7 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(251, 119, 60, 0.4);
+      background: rgba(68, 161, 148, 0.4);
       color: #cdd9ff;
       font-size: 0.82rem;
       letter-spacing: 0.08em;
@@ -189,7 +189,7 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(235, 54, 120, 0.22);
+      background: rgba(236, 143, 141, 0.22);
       color: var(--gold);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
@@ -231,15 +231,15 @@
       margin-top: 24px;
       padding: 14px 16px;
       border-radius: 14px;
-      border: 1px solid rgba(251, 119, 60, 0.55);
-      background: rgba(79, 23, 135, 0.74);
-      color: #FDF2FF;
+      border: 1px solid rgba(68, 161, 148, 0.55);
+      background: rgba(68, 161, 148, 0.74);
+      color: #F4F0E4;
       font-size: 0.95rem;
     }
 
     .site-footer {
       margin-top: 24px;
-      border-top: 1px solid rgba(251, 119, 60, 0.4);
+      border-top: 1px solid rgba(68, 161, 148, 0.4);
       background: rgba(5, 7, 11, 0.85);
     }
 

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -6,13 +6,13 @@
   <title>Plugin Suggestions | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.5);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.5);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -87,7 +87,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
+    .btn-secondary { background: rgba(68, 161, 148, 0.4); color: var(--text); }
   </style>
 </head>
 <body>

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -1,13 +1,13 @@
 :root {
-  --bg1: #180161;
-  --bg2: #4F1787;
-  --panel: rgba(79, 23, 135, 0.88);
-  --line: rgba(251, 119, 60, 0.52);
-  --text: #FDF2FF;
-  --muted: #F3B6DA;
-  --accent: #FB773C;
-  --accent-2: #4F1787;
-  --warn: #FB773C;
+  --bg1: #537D96;
+  --bg2: #44A194;
+  --panel: rgba(68, 161, 148, 0.88);
+  --line: rgba(68, 161, 148, 0.52);
+  --text: #F4F0E4;
+  --muted: #EC8F8D;
+  --accent: #44A194;
+  --accent-2: #44A194;
+  --warn: #44A194;
 }
 * { box-sizing: border-box; }
 body {
@@ -16,17 +16,17 @@ body {
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at 12% 12%, rgba(235, 54, 120, 0.28), transparent 28%),
-    radial-gradient(circle at 88% 10%, rgba(251, 119, 60, 0.24), transparent 32%),
+    radial-gradient(circle at 12% 12%, rgba(236, 143, 141, 0.28), transparent 28%),
+    radial-gradient(circle at 88% 10%, rgba(68, 161, 148, 0.24), transparent 32%),
     linear-gradient(165deg, var(--bg1), var(--bg2));
 }
 .page {
   width: min(calc(100% - 28px), 1050px);
   margin: 22px auto 34px;
   padding: 26px;
-  border: 1px solid rgba(251, 119, 60, 0.44);
+  border: 1px solid rgba(68, 161, 148, 0.44);
   border-radius: 24px;
-  background: rgba(79, 23, 135, 0.82);
+  background: rgba(68, 161, 148, 0.82);
   backdrop-filter: blur(6px);
 }
 .back-link {
@@ -52,7 +52,7 @@ body {
   width: 120px;
   image-rendering: pixelated;
   border-radius: 10px;
-  border: 2px solid rgba(24, 1, 97, 0.9);
+  border: 2px solid rgba(83, 125, 150, 0.9);
   background: rgba(0, 0, 0, 0.3);
 }
 .head-placeholder {
@@ -64,7 +64,7 @@ body {
   text-align: center;
   line-height: 1.4;
   border-radius: 10px;
-  border: 2px dashed rgba(251, 119, 60, 0.76);
+  border: 2px dashed rgba(68, 161, 148, 0.76);
   color: var(--warn);
   background: rgba(0, 0, 0, 0.25);
   padding: 10px;
@@ -105,7 +105,7 @@ body {
   display: flex;
   justify-content: space-between;
   gap: 14px;
-  border-bottom: 1px solid rgba(251, 119, 60, 0.4);
+  border-bottom: 1px solid rgba(68, 161, 148, 0.4);
   padding-bottom: 6px;
 }
 .label { color: var(--muted); }
@@ -128,10 +128,10 @@ body {
 .chip {
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(251, 119, 60, 0.52);
+  border: 1px solid rgba(68, 161, 148, 0.52);
   color: var(--muted);
   font-size: 0.9rem;
-  background: rgba(235, 54, 120, 0.25);
+  background: rgba(236, 143, 141, 0.25);
 }
 .footnote {
   margin-top: 16px;

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -6,15 +6,15 @@
   <title>Tournament Standings | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.55);
-      --gold: #FB773C;
-      --silver: #4F1787;
-      --bronze: #180161;
-      --accent: #FB773C;
-      --green: #EB3678;
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.55);
+      --gold: #44A194;
+      --silver: #44A194;
+      --bronze: #537D96;
+      --accent: #44A194;
+      --green: #EC8F8D;
     }
 
     * { box-sizing: border-box; }
@@ -26,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -47,9 +47,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(11, 16, 24, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(11, 16, 24, 0.9) 100%);
     }
 
     .container {
@@ -96,7 +96,7 @@
     }
 
     .entry {
-      border: 1px solid rgba(251, 119, 60, 0.44);
+      border: 1px solid rgba(68, 161, 148, 0.44);
       border-radius: 14px;
       padding: 12px 14px;
       background: rgba(11, 16, 24, 0.68);
@@ -135,12 +135,12 @@
     .fill {
       height: 100%;
       border-radius: inherit;
-      background: linear-gradient(90deg, #FB773C 0%, #EB3678 100%);
+      background: linear-gradient(90deg, #44A194 0%, #EC8F8D 100%);
     }
 
     .entry[data-rank="1"] {
-      border-color: rgba(251, 119, 60, 0.7);
-      box-shadow: 0 0 0 1px rgba(251, 119, 60, 0.4) inset;
+      border-color: rgba(68, 161, 148, 0.7);
+      box-shadow: 0 0 0 1px rgba(68, 161, 148, 0.4) inset;
     }
 
     .entry[data-rank="2"] {

--- a/vote-history.html
+++ b/vote-history.html
@@ -6,15 +6,15 @@
   <title>Vote History | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --line: rgba(251, 119, 60, 0.55);
-      --panel: rgba(79, 23, 135, 0.88);
-      --panel-strong: rgba(79, 23, 135, 0.9);
-      --cyan: #FB773C;
-      --green: #EB3678;
-      --gold: #FB773C;
-      --pink: #FB773C;
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --line: rgba(68, 161, 148, 0.55);
+      --panel: rgba(68, 161, 148, 0.88);
+      --panel-strong: rgba(68, 161, 148, 0.9);
+      --cyan: #44A194;
+      --green: #EC8F8D;
+      --gold: #44A194;
+      --pink: #44A194;
       --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
     }
 
@@ -27,7 +27,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -48,17 +48,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1220px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/vote-links.html
+++ b/vote-links.html
@@ -6,14 +6,14 @@
   <title>Vote Links | Pinnacle SMP</title>
   <style>
     :root {
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --line: rgba(251, 119, 60, 0.55);
-      --panel: rgba(79, 23, 135, 0.86);
-      --cyan: #FB773C;
-      --green: #EB3678;
-      --gold: #FB773C;
-      --violet: #FB773C;
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --line: rgba(68, 161, 148, 0.55);
+      --panel: rgba(68, 161, 148, 0.86);
+      --cyan: #44A194;
+      --green: #EC8F8D;
+      --gold: #44A194;
+      --violet: #44A194;
     }
 
     * { box-sizing: border-box; }
@@ -25,7 +25,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -46,17 +46,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1200px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -6,13 +6,13 @@
   <title>Whitelist Application | Pinnacle SMP</title>
   <style>
     :root {
-      --bg: #180161;
-      --panel: rgba(79, 23, 135, 0.88);
-      --line: rgba(251, 119, 60, 0.5);
-      --text: #FDF2FF;
-      --muted: #F3B6DA;
-      --green: #EB3678;
-      --cyan: #FB773C;
+      --bg: #537D96;
+      --panel: rgba(68, 161, 148, 0.88);
+      --line: rgba(68, 161, 148, 0.5);
+      --text: #F4F0E4;
+      --muted: #EC8F8D;
+      --green: #EC8F8D;
+      --cyan: #44A194;
       --radius: 20px;
     }
     * { box-sizing: border-box; }
@@ -23,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #180161;
+      background: #537D96;
     }
 
     body::before {
@@ -44,16 +44,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(235, 54, 120, 0.28), transparent 33%),
-        radial-gradient(circle at top right, rgba(251, 119, 60, 0.3), transparent 30%),
-        linear-gradient(180deg, rgba(79, 23, 135, 0.78) 0%, rgba(24, 1, 97, 0.9) 100%);
+        radial-gradient(circle at top left, rgba(236, 143, 141, 0.28), transparent 33%),
+        radial-gradient(circle at top right, rgba(68, 161, 148, 0.3), transparent 30%),
+        linear-gradient(180deg, rgba(68, 161, 148, 0.78) 0%, rgba(83, 125, 150, 0.9) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(79, 23, 135, 0.84);
-      border: 1px solid rgba(251, 119, 60, 0.48);
+      background: rgba(68, 161, 148, 0.84);
+      border: 1px solid rgba(68, 161, 148, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -107,7 +107,7 @@
       justify-content: center;
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(251, 119, 60, 0.4); color: var(--text); }
+    .btn-secondary { background: rgba(68, 161, 148, 0.4); color: var(--text); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Replace the existing purple/pink/orange theme with the provided four-color palette to give the site a cohesive new look.
- Apply the palette consistently to backgrounds, panels, borders, accents, and text across site pages and the shared profile stylesheet.

### Description
- Replaced hex and rgba color tokens (backgrounds, gradients, panel opacities, borders, and accents) with the new palette and updated CSS variables in the main HTML files and `profiles/profile.css`.
- Updated inline `:root` variables and any hardcoded color uses (including gradient stops and `rgba(...)` values) so `--bg`, `--panel`, `--line`, `--text`, `--muted`, `--cyan`, `--green`, etc., reflect the new palette.
- Files updated include `index.html`, `news.html`, `members.html`, `vote-links.html`, `vote-history.html`, `tournament-standings.html`, `about-season-12.html`, `about-us.html`, `faq.html`, `contact-us.html`, `ban-appeal.html`, `plugin-suggestions.html`, `whitelist-application.html`, and `profiles/profile.css`.
- All changes are visual only and were committed on the working branch.

### Testing
- Ran a repository-wide search with `rg` to find old palette tokens and confirmed the previous color tokens were removed (no matches found), which succeeded.
- Executed the replacement script (Python) that printed the modified files and then created a commit; `git commit` completed successfully (14 files changed, 244 insertions(+), 244 deletions(-)).
- Verified the working tree is clean with `git status --short`, which reported no outstanding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4517a2d9c832fa666f584c6c7584a)