### PR TITLE
Fix low-contrast text on News page main panel and edit note

### DIFF
--- a/news.html
+++ b/news.html
@@ -11,6 +11,7 @@
       --panel: rgba(83, 125, 150, 0.88);
       --line: rgba(244, 240, 228, 0.55);
       --text: #F4F0E4;
+      --ink: #1D2E3D;
       --muted: #EC8F8D;
       --green: #44A194;
       --cyan: #44A194;
@@ -74,6 +75,7 @@
       border: 1px solid rgba(244, 240, 228, 0.48);
       border-radius: 26px;
       backdrop-filter: blur(8px);
+      color: var(--ink);
     }
 
     .site-header {
@@ -83,6 +85,7 @@
       backdrop-filter: blur(16px);
       background: rgba(244, 240, 228, 0.84);
       border-bottom: 1px solid rgba(244, 240, 228, 0.4);
+      color: var(--ink);
     }
 
     .nav-wrap {
@@ -119,7 +122,7 @@
       border-radius: 12px;
       border: 1px solid rgba(122,162,255,0.2);
       background: rgba(122,162,255,0.11);
-      color: var(--text);
+      color: var(--ink);
       font-weight: 700;
       transition: 0.2s ease;
     }
@@ -170,6 +173,7 @@
       box-shadow: var(--shadow);
       overflow: hidden;
       scroll-margin-top: 110px;
+      color: var(--text);
     }
 
     .article-header {
@@ -233,7 +237,7 @@
       border-radius: 14px;
       border: 1px solid rgba(244, 240, 228, 0.55);
       background: rgba(244, 240, 228, 0.74);
-      color: #F4F0E4;
+      color: #24384B;
       font-size: 0.95rem;
     }
 


### PR DESCRIPTION
### Motivation
- The new light main panel and updated palette reduced contrast between page background and global text, making primary copy and navigation hard to read.
- The `.edit-note` callout used a near-matching foreground color that removed readable separation from its light background.

### Description
- Added a dark foreground token `--ink` and applied it to the light `main` panel and `.site-header` so primary content and navigation text maintain contrast.
- Updated the header/back button to use `--ink` for improved legibility against the light header background.
- Kept article cards using the original light `--text` foreground so dark cards preserve their contrast against their background surfaces.
- Changed `.edit-note` text color to `#24384B` for clear foreground/background separation on the callout.

### Testing
- Verified the styling patch with `git diff -- news.html` which showed the intended changes and succeeded.
- Verified repository status with `git status --short` and confirmed the file was staged/modified successfully.
- Attempted HTML validation using `xmllint --html --noout news.html` but the tool is not installed in this environment so content validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4556ebbd8832f8133efba6215a06a)