### PR TITLE
Introduce centralized light theme and replace hardcoded dark styles

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -4,12 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About Season 12 | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.42);
       --cyan: #72e0ff;
       --green: #7affb4;
     }
@@ -23,7 +20,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,17 +41,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 28px auto 52px;
       padding: 30px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -72,7 +69,7 @@
       border: 1px solid var(--line);
       border-radius: 24px;
       padding: 30px;
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
     }
 
     h1 {

--- a/about-us.html
+++ b/about-us.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About Us | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.84);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.42);
       --cyan: #72e0ff;
       --green: #7affb4;
     }
@@ -23,7 +19,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,17 +40,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1100px);
       margin: 0 auto;
       padding: 36px 0 54px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -72,7 +68,7 @@
       border: 1px solid var(--line);
       border-radius: 24px;
       padding: 28px;
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
     }
 
     .hero-logo {

--- a/assets/light-theme.css
+++ b/assets/light-theme.css
@@ -1,0 +1,28 @@
+:root {
+  --bg: #eef3ff;
+  --bg-soft: #e4ecff;
+  --surface: #f7faff;
+  --panel: rgba(255, 255, 255, 0.86);
+  --panel-strong: rgba(245, 250, 255, 0.95);
+  --panel-2: rgba(240, 247, 255, 0.92);
+  --line: rgba(92, 125, 183, 0.28);
+  --text: #162744;
+  --muted: #506388;
+  --shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
+  --overlay-top-left: rgba(114, 224, 255, 0.18);
+  --overlay-top-right: rgba(146, 255, 198, 0.16);
+  --overlay-base-start: rgba(255, 255, 255, 0.76);
+  --overlay-base-end: rgba(238, 244, 255, 0.9);
+  --frosted-bg: rgba(255, 255, 255, 0.72);
+  --frosted-line: rgba(124, 153, 205, 0.3);
+  --input-bg: rgba(255, 255, 255, 0.94);
+  --input-line: rgba(122, 162, 255, 0.3);
+  --nav-bg: rgba(255, 255, 255, 0.82);
+  --nav-line: rgba(141, 181, 255, 0.26);
+  --btn-secondary-bg: rgba(141, 181, 255, 0.2);
+  --btn-secondary-hover: rgba(87, 213, 255, 0.2);
+  --glass-dark-weak: rgba(130, 154, 196, 0.16);
+  --glass-dark-mid: rgba(130, 154, 196, 0.24);
+  --surface-veil: rgba(255, 255, 255, 0.7);
+  --text-inverse: #ffffff;
+}

--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ban Appeal | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.4);
       --green: #7affb4;
       --cyan: #72e0ff;
       --radius: 20px;
@@ -23,7 +19,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,16 +40,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -72,7 +68,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(19, 30, 48, 0.94);
+      background: var(--input-bg);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -91,8 +87,8 @@
       align-items: center;
       justify-content: center;
     }
-    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
+    .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
   </style>
 </head>
 <body>

--- a/contact-us.html
+++ b/contact-us.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact Us | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.4);
       --green: #7affb4;
       --cyan: #72e0ff;
       --radius: 20px;
@@ -23,7 +19,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,16 +40,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -67,7 +63,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(19, 30, 48, 0.94);
+      background: var(--input-bg);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -86,8 +82,8 @@
       align-items: center;
       justify-content: center;
     }
-    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
+    .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
   </style>
 </head>
 <body>

--- a/faq.html
+++ b/faq.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FAQs | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.4);
       --green: #7affb4;
       --cyan: #72e0ff;
       --radius: 20px;
@@ -26,7 +22,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -47,17 +43,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), var(--max));
       margin: 0 auto;
       padding: 36px 0 52px;
-          background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+          background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -87,7 +83,7 @@
     }
 
     details {
-      background: rgba(19, 30, 48, 0.88);
+      background: var(--input-bg);
       border: 1px solid rgba(122, 162, 255, 0.2);
       border-radius: 14px;
       padding: 14px 16px;
@@ -133,11 +129,11 @@
 
     .btn-primary {
       background: linear-gradient(135deg, var(--green), var(--cyan));
-      color: #03150d;
+      color: var(--text);
     }
 
     .btn-secondary {
-      background: rgba(141, 181, 255, 0.2);
+      background: var(--btn-secondary-bg);
       color: var(--text);
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -4,21 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --bg-soft: #101521;
-      --panel: rgba(40, 57, 88, 0.87);
-      --panel-2: rgba(48, 67, 102, 0.9);
-      --line: rgba(173, 214, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {            --line: rgba(173, 214, 255, 0.42);
       --green: #7affb4;
       --cyan: #72e0ff;
       --blue: #8db5ff;
       --gold: #ffe082;
       --danger: #ff6c8f;
-      --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      --shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
       --radius: 22px;
       --max: 1240px;
     }
@@ -32,7 +26,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -53,9 +47,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     a {
@@ -92,8 +86,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -103,8 +97,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
     }
 
     .nav-wrap {
@@ -148,7 +142,7 @@
       padding: 7px 12px;
       border-radius: 999px;
       border: 1px solid rgba(141, 181, 255, 0.44);
-      background: rgba(20, 34, 52, 0.74);
+      background: var(--surface-veil);
       color: var(--muted);
       font-size: 0.84rem;
       font-weight: 700;
@@ -204,7 +198,7 @@
       padding: 0 14px;
       border-radius: 12px;
       border: 1px solid rgba(141, 181, 255, 0.34);
-      background: rgba(141, 181, 255, 0.2);
+      background: var(--btn-secondary-bg);
       color: var(--text);
       font-weight: 700;
       font: inherit;
@@ -239,7 +233,7 @@
 
     nav > ul > li > a:hover,
     nav > ul > li > a:focus {
-      background: rgba(141, 181, 255, 0.2);
+      background: var(--btn-secondary-bg);
       color: white;
       outline: none;
     }
@@ -270,8 +264,8 @@
     .hero-card {
       padding: 36px;
       background:
-        linear-gradient(145deg, rgba(9, 14, 23, 0.72), rgba(8, 12, 20, 0.78)),
-        linear-gradient(180deg, rgba(7, 10, 17, 0.42), rgba(7, 10, 17, 0.62)),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.76), rgba(233, 241, 255, 0.88)),
+        linear-gradient(180deg, rgba(233, 241, 255, 0.5), rgba(233, 241, 255, 0.74)),
         url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
     }
 
@@ -281,8 +275,8 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(141, 181, 255, 0.2);
-      color: #cdd9ff;
+      background: var(--btn-secondary-bg);
+      color: var(--muted);
       font-size: 0.82rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
@@ -339,7 +333,7 @@
 
     .btn-primary {
       background: linear-gradient(135deg, var(--green), var(--cyan));
-      color: #05110b;
+      color: var(--text);
     }
 
     .btn-secondary {
@@ -349,9 +343,9 @@
     }
 
     .btn-disabled {
-      background: rgba(255,255,255,0.06);
-      border-color: rgba(255,255,255,0.14);
-      color: rgba(230,236,255,0.55);
+      background: rgba(141, 181, 255, 0.14);
+      border-color: rgba(122, 162, 255, 0.26);
+      color: var(--muted);
       cursor: not-allowed;
       pointer-events: none;
       opacity: 0.7;
@@ -368,7 +362,7 @@
     .hover-lift:hover,
     .hover-lift:focus-within {
       transform: translateY(-6px);
-      box-shadow: 0 18px 34px rgba(0, 0, 0, 0.42), 0 0 0 1px rgba(122, 162, 255, 0.18);
+      box-shadow: 0 18px 34px rgba(70, 97, 146, 0.22), 0 0 0 1px rgba(122, 162, 255, 0.18);
       border-color: rgba(122, 162, 255, 0.45);
     }
 
@@ -389,7 +383,7 @@
       gap: 18px;
       background:
         radial-gradient(circle at top right, rgba(122,162,255,0.16), transparent 40%),
-        linear-gradient(180deg, rgba(18,24,37,0.96), rgba(11,15,24,0.96));
+        linear-gradient(180deg, rgba(252, 254, 255, 0.96), rgba(235, 243, 255, 0.96));
     }
 
     .server-card {
@@ -553,8 +547,8 @@
 
     .site-footer {
       margin-top: 48px;
-      border-top: 1px solid rgba(141, 181, 255, 0.2);
-      background: rgba(5, 7, 11, 0.85);
+      border-top: 1px solid var(--btn-secondary-bg);
+      background: var(--nav-bg);
     }
 
     .footer-grid {
@@ -575,7 +569,7 @@
       font-size: 0.95rem;
       text-transform: uppercase;
       letter-spacing: 0.08em;
-      color: #d8e2ff;
+      color: var(--text);
     }
 
     .footer-links {

--- a/members.html
+++ b/members.html
@@ -4,12 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Members | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.42);
       --cyan: #72e0ff;
       --green: #7affb4;
       --gold: #ffe082;
@@ -26,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -47,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1120px);
       margin: 0 auto;
       padding: 36px 0 54px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -75,7 +72,7 @@
       border: 1px solid var(--line);
       border-radius: 24px;
       padding: 30px;
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
     }
 
     h1 {
@@ -100,7 +97,7 @@
       border: 1px solid rgba(156, 191, 236, 0.25);
       border-radius: 16px;
       padding: 18px;
-      background: rgba(24, 34, 54, 0.45);
+      background: var(--surface-veil);
     }
 
     .member-section h2 {
@@ -152,7 +149,7 @@
     .member-button:focus-visible {
       transform: translateY(-1px);
       border-color: var(--cyan);
-      background: rgba(87, 213, 255, 0.2);
+      background: var(--btn-secondary-hover);
       outline: none;
     }
 
@@ -161,7 +158,7 @@
       border: 1px solid rgba(156, 191, 236, 0.25);
       border-radius: 16px;
       padding: 22px 18px;
-      background: rgba(24, 34, 54, 0.45);
+      background: var(--surface-veil);
       text-align: center;
     }
 

--- a/news.html
+++ b/news.html
@@ -4,19 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pinnacle SMP • Server News</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --bg-soft: #101521;
-      --panel: rgba(40, 57, 88, 0.87);
-      --line: rgba(173, 214, 255, 0.42);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(173, 214, 255, 0.42);
       --green: #7affb4;
       --cyan: #72e0ff;
       --blue: #8db5ff;
       --gold: #ffe082;
-      --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      --shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
       --radius: 22px;
       --max: 1040px;
     }
@@ -30,7 +25,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -51,9 +46,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     a { color: inherit; text-decoration: none; }
@@ -70,8 +65,8 @@
       width: min(calc(100% - 32px), var(--max));
       margin: 28px auto 46px;
       padding: 8px 22px 28px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -81,8 +76,8 @@
       top: 0;
       z-index: 50;
       backdrop-filter: blur(16px);
-      background: rgba(7, 10, 15, 0.72);
-      border-bottom: 1px solid rgba(141, 181, 255, 0.2);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
     }
 
     .nav-wrap {
@@ -139,8 +134,8 @@
       gap: 8px;
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(141, 181, 255, 0.2);
-      color: #cdd9ff;
+      background: var(--btn-secondary-bg);
+      color: var(--muted);
       font-size: 0.82rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
@@ -197,7 +192,7 @@
     }
 
     .date {
-      color: #bfcbeb;
+      color: var(--muted);
       font-size: 0.95rem;
       font-weight: 600;
     }
@@ -239,8 +234,8 @@
 
     .site-footer {
       margin-top: 24px;
-      border-top: 1px solid rgba(141, 181, 255, 0.2);
-      background: rgba(5, 7, 11, 0.85);
+      border-top: 1px solid var(--btn-secondary-bg);
+      background: var(--nav-bg);
     }
 
     .footer-content {

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Plugin Suggestions | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.4);
       --green: #7affb4;
       --cyan: #72e0ff;
       --radius: 20px;
@@ -23,7 +19,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,16 +40,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -67,7 +63,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(19, 30, 48, 0.94);
+      background: var(--input-bg);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -86,8 +82,8 @@
       align-items: center;
       justify-content: center;
     }
-    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
+    .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
   </style>
 </head>
 <body>

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -1,13 +1,14 @@
+@import url("../assets/light-theme.css");
+
 :root {
-  --bg1: #13203a;
-  --bg2: #1e2e4d;
-  --panel: rgba(35, 49, 78, 0.9);
-  --line: rgba(150, 193, 255, 0.45);
-  --text: #f4f8ff;
-  --muted: #d1dcf6;
-  --accent: #74e2ff;
-  --accent-2: #95ffd0;
-  --warn: #ffe082;
+  --bg1: #edf3ff;
+  --bg2: #dbe7ff;
+  --panel: rgba(255, 255, 255, 0.9);
+  --line: rgba(120, 154, 211, 0.42);
+  --muted: #5a6f95;
+  --accent: #2f76c7;
+  --accent-2: #3ea16f;
+  --warn: #b07b00;
 }
 * { box-sizing: border-box; }
 body {
@@ -26,7 +27,7 @@ body {
   padding: 26px;
   border: 1px solid rgba(167, 193, 255, 0.25);
   border-radius: 24px;
-  background: rgba(20, 30, 50, 0.68);
+  background: var(--frosted-bg);
   backdrop-filter: blur(6px);
 }
 .back-link {
@@ -53,7 +54,7 @@ body {
   image-rendering: pixelated;
   border-radius: 10px;
   border: 2px solid rgba(98, 212, 255, 0.7);
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(255, 255, 255, 0.5);
 }
 .head-placeholder {
   width: 120px;
@@ -66,7 +67,7 @@ body {
   border-radius: 10px;
   border: 2px dashed rgba(255, 214, 107, 0.8);
   color: var(--warn);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(255, 255, 255, 0.65);
   padding: 10px;
 }
 .name {

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -4,12 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tournament Standings | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --panel: rgba(38, 53, 82, 0.88);
-      --line: rgba(168, 208, 255, 0.45);
+    :root {      --line: rgba(168, 208, 255, 0.45);
       --gold: #ffe082;
       --silver: #dbe8ff;
       --bronze: #ffb27a;
@@ -26,7 +23,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -47,9 +44,9 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.9) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
@@ -71,7 +68,7 @@
       border: 1px solid var(--line);
       border-radius: 24px;
       padding: 26px;
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
       margin-bottom: 20px;
     }
 
@@ -87,7 +84,7 @@
       overflow: hidden;
       border-radius: 16px;
       border: 1px solid rgba(87, 213, 255, 0.3);
-      background: rgba(11, 16, 24, 0.75);
+      background: var(--surface-veil);
     }
 
     .scoreboard {
@@ -99,7 +96,7 @@
       border: 1px solid rgba(156, 191, 236, 0.24);
       border-radius: 14px;
       padding: 12px 14px;
-      background: rgba(11, 16, 24, 0.68);
+      background: var(--surface-veil);
     }
 
     .entry-head {

--- a/vote-history.html
+++ b/vote-history.html
@@ -4,18 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vote History | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
     :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --line: rgba(168, 208, 255, 0.42);
-      --panel: rgba(38, 53, 82, 0.86);
-      --panel-strong: rgba(44, 61, 92, 0.9);
-      --cyan: #72e0ff;
+      --line: rgba(168, 208, 255, 0.42);            --cyan: #72e0ff;
       --green: #7affb4;
       --gold: #ffe082;
       --pink: #ff8ec1;
-      --shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      --shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
     }
 
     * { box-sizing: border-box; }
@@ -27,7 +23,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -48,17 +44,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1220px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -158,7 +154,7 @@
       font-weight: 700;
       letter-spacing: 0.07em;
       text-transform: uppercase;
-      color: #08131e;
+      color: var(--text);
       background: linear-gradient(135deg, var(--green), var(--gold));
       border-radius: 999px;
       padding: 6px 10px;

--- a/vote-links.html
+++ b/vote-links.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vote Links | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
     :root {
-      --text: #f4f8ff;
-      --muted: #d4def7;
-      --line: rgba(168, 208, 255, 0.42);
-      --panel: rgba(38, 53, 82, 0.84);
-      --cyan: #72e0ff;
+      --line: rgba(168, 208, 255, 0.42);      --cyan: #72e0ff;
       --green: #7affb4;
       --gold: #ffe082;
       --violet: #b6a2ff;
@@ -25,7 +22,7 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -46,17 +43,17 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
 
     .container {
       width: min(calc(100% - 32px), 1200px);
       margin: 0 auto;
       padding: 34px clamp(18px, 3vw, 40px) 48px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -104,7 +101,7 @@
       border: 1px solid var(--line);
       border-radius: 20px;
       padding: 20px;
-      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+      box-shadow: 0 18px 48px rgba(70, 97, 146, 0.24);
       display: flex;
       flex-direction: column;
       gap: 10px;
@@ -130,7 +127,7 @@
       font-size: 0.78rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: #0f1118;
+      color: var(--text);
       font-weight: 700;
       background: linear-gradient(135deg, var(--green), var(--gold));
     }

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -4,13 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Whitelist Application | Pinnacle SMP</title>
+    <link rel="stylesheet" href="assets/light-theme.css" />
   <style>
-    :root {
-      --bg: #10172a;
-      --panel: rgba(38, 53, 82, 0.86);
-      --line: rgba(168, 208, 255, 0.4);
-      --text: #f4f8ff;
-      --muted: #d4def7;
+    :root {      --line: rgba(168, 208, 255, 0.4);
       --green: #7affb4;
       --cyan: #72e0ff;
       --radius: 20px;
@@ -23,7 +19,7 @@
       min-height: 100vh;
       position: relative;
       overflow-x: hidden;
-      background: #16223a;
+      background: var(--bg-soft);
     }
 
     body::before {
@@ -44,16 +40,16 @@
       z-index: -1;
       pointer-events: none;
       background:
-        radial-gradient(circle at top left, rgba(116, 232, 255, 0.2), transparent 33%),
-        radial-gradient(circle at top right, rgba(146, 255, 198, 0.2), transparent 30%),
-        linear-gradient(180deg, rgba(12, 17, 28, 0.82) 0%, rgba(11, 16, 24, 0.88) 100%);
+        radial-gradient(circle at top left, var(--overlay-top-left), transparent 33%),
+        radial-gradient(circle at top right, var(--overlay-top-right), transparent 30%),
+        linear-gradient(180deg, var(--overlay-base-start) 0%, var(--overlay-base-end) 100%);
     }
     .container {
       width: min(calc(100% - 32px), 860px);
       margin: 0 auto;
       padding: 36px 0 52px;
-      background: rgba(24, 36, 58, 0.68);
-      border: 1px solid rgba(162, 196, 255, 0.2);
+      background: var(--frosted-bg);
+      border: 1px solid var(--frosted-line);
       border-radius: 26px;
       backdrop-filter: blur(8px);
     }
@@ -72,7 +68,7 @@
       width: 100%;
       border-radius: 12px;
       border: 1px solid rgba(122, 162, 255, 0.24);
-      background: rgba(19, 30, 48, 0.94);
+      background: var(--input-bg);
       color: var(--text);
       padding: 12px 14px;
       font: inherit;
@@ -106,8 +102,8 @@
       align-items: center;
       justify-content: center;
     }
-    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: #03150d; }
-    .btn-secondary { background: rgba(141, 181, 255, 0.2); color: var(--text); }
+    .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
+    .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Replace many scattered hardcoded dark-theme color literals, overlays and gradients with a single, reusable light-theme palette to enable consistent light-mode styling and reduce duplication.
- Move all surface/text/overlay/button tokens into a central file so pages can share the same design tokens and be easier to maintain.

### Description
- Added a new palette file `assets/light-theme.css` that exposes tokens for backgrounds, frosted panels, overlays, nav/footer surfaces, text, muted text, shadows, and secondary button states.
- Updated top-level pages to import the palette and replace hardcoded dark colors, rgba black overlays, gradients, nav/footer backgrounds, card surfaces, and button hover/text colors with the shared CSS variables; files updated include `index.html`, `news.html`, `about-us.html`, `about-season-12.html`, `contact-us.html`, `faq.html`, `ban-appeal.html`, `plugin-suggestions.html`, `whitelist-application.html`, `members.html`, `vote-links.html`, `vote-history.html`, and `tournament-standings.html`.
- Refactored `profiles/profile.css` to import the centralized palette and switched avatar/placeholders and page containers from dark translucent overlays to light frosted surfaces using the new tokens.
- Normalized repeated full-page overlay gradients and button styles to use `--overlay-*`, `--frosted-bg`, `--btn-secondary-bg`, and other tokens for consistent rendering.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or diff-check errors and it reported no issues.
- Performed repository-wide searches with `rg` to locate previous hardcoded dark tokens and rgba black overlays and verified those patterns no longer appear in the refactored HTML/CSS scope.
- Confirmed each modified HTML file now includes the `assets/light-theme.css` import and that `profiles/profile.css` is updated to import the palette.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c42158f0832fb3abda399be335e1)