### PR TITLE
Improve homepage theme readability and reduce wallpaper blur

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       z-index: -2;
       pointer-events: none;
       background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      filter: blur(3px) brightness(0.5) saturate(1.08);
       transform: scale(1.03);
     }
 
@@ -162,8 +162,9 @@
     }
 
     .brand-status.online {
-      color: #d9ffe8;
+      color: #237750;
       border-color: rgba(95, 255, 156, 0.55);
+      background: rgba(239, 245, 242, 0.92);
     }
 
     .brand-status.online .brand-status-dot {
@@ -264,8 +265,8 @@
     .hero-card {
       padding: 36px;
       background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.76), rgba(233, 241, 255, 0.88)),
-        linear-gradient(180deg, rgba(233, 241, 255, 0.5), rgba(233, 241, 255, 0.74)),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.68), rgba(233, 241, 255, 0.78)),
+        linear-gradient(180deg, rgba(233, 241, 255, 0.45), rgba(233, 241, 255, 0.64)),
         url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
     }
 
@@ -398,7 +399,7 @@
       font-size: 1.15rem;
       font-weight: 800;
       letter-spacing: 0.04em;
-      color: var(--green);
+      color: #237750;
     }
 
     .status-grid {
@@ -476,7 +477,7 @@
       letter-spacing: 0.05em;
       text-transform: uppercase;
       font-size: 0.8rem;
-      color: #d6e2ff;
+      color: #2b456f;
       background: rgba(141, 181, 255, 0.16);
     }
 
@@ -508,8 +509,9 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(255, 214, 107, 0.1);
-      color: var(--gold);
+      background: rgba(95, 255, 156, 0.14);
+      color: #1f6f49;
+      border: 1px solid rgba(95, 255, 156, 0.3);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;


### PR DESCRIPTION
### Motivation
- Improve accessibility and legibility of the homepage UI elements that were difficult to read on the light background. 
- Preserve the green accent used in branding while increasing contrast for badges, tags, and the server IP. 
- Make the background wallpaper more visible by reducing the heavy blur while keeping text readable. 

### Description
- Reduced the global wallpaper blur from `blur(7px)` to `blur(3px)` and adjusted brightness/saturation for the page background in `index.html`.
- Lowered the hero card overlay opacity by tweaking its gradient stops so the wallpaper shows through more clearly in `index.html`.
- Updated the online status badge `.brand-status.online` to use a darker green text color `#237750` and added a light off-white badge background for improved contrast in `index.html`.
- Changed the server IP text color (`.server-ip`) to `#237750`, darkened events table header text to `#2b456f`, and converted yellow tags to a green scheme with a subtle border for better readability, all in `index.html`.

### Testing
- Ran `git diff --check` to verify there are no patch formatting issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c8ff3a80832fa28f8a40f7ffc5aa)