### PR TITLE
Adjust news page announcement pill and jump section contrast

### DIFF
--- a/news.html
+++ b/news.html
@@ -184,8 +184,9 @@
       width: fit-content;
       padding: 7px 10px;
       border-radius: 999px;
-      background: rgba(255, 214, 107, 0.1);
-      color: var(--gold);
+      background: rgba(95, 255, 156, 0.14);
+      color: #1f6f49;
+      border: 1px solid rgba(95, 255, 156, 0.3);
       font-size: 0.78rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
@@ -226,9 +227,9 @@
       margin-top: 24px;
       padding: 14px 16px;
       border-radius: 14px;
-      border: 1px solid rgba(95,255,156,0.2);
-      background: rgba(95,255,156,0.06);
-      color: #d6ffe8;
+      border: 1px solid rgba(141, 181, 255, 0.28);
+      background: rgba(27, 42, 72, 0.72);
+      color: #e7f2ff;
       font-size: 0.95rem;
     }
 


### PR DESCRIPTION
### Motivation
- Make the announcement pill on the news page visually consistent with the index page and improve the legibility of the “Jump to article” callout which was too bright.

### Description
- Updated the announcement pill styling in `news.html` by changing the `.tag` rule to use a green background, darker green text, and a matching green border for parity with the index card treatment.
- Darkened the `Jump to article` callout by adjusting the `.edit-note` rule in `news.html` to use a deeper blue background and tuned the border and text color for improved contrast.

### Testing
- No automated tests were run because this is a static HTML/CSS change; visual verification via the site is expected as the validation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cb40a340832fa4e70d1f227e58e9)