### PR TITLE
Add live server status service and online indicators for members and profiles

### DIFF
--- a/assets/server-status.js
+++ b/assets/server-status.js
@@ -1,0 +1,31 @@
+(() => {
+  const STATUS_API = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
+
+  const fetchServerStatus = async () => {
+    try {
+      const response = await fetch(STATUS_API, { cache: "no-store" });
+      if (!response.ok) throw new Error("Bad response");
+      const data = await response.json();
+
+      if (!data?.online) {
+        return { online: false, playersOnline: 0, onlinePlayers: [] };
+      }
+
+      const onlinePlayers = Array.isArray(data.players?.list)
+        ? data.players.list.filter((player) => typeof player === "string")
+        : [];
+
+      return {
+        online: true,
+        playersOnline: Number(data.players?.online ?? onlinePlayers.length ?? 0),
+        onlinePlayers
+      };
+    } catch (error) {
+      return { online: false, playersOnline: 0, onlinePlayers: [] };
+    }
+  };
+
+  window.PinnacleServerStatus = {
+    fetchServerStatus
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -152,6 +152,14 @@
       white-space: nowrap;
     }
 
+    .brand-status,
+    .brand-status:hover,
+    .brand-status:focus-visible {
+      text-decoration: none;
+      background-image: none;
+    }
+
+    .status-dot,
     .brand-status-dot {
       width: 10px;
       height: 10px;
@@ -773,10 +781,10 @@
           <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
           <span>Pinnacle SMP</span>
         </a>
-        <span id="server-status-badge" class="brand-status" aria-live="polite">
-          <span class="brand-status-dot" aria-hidden="true"></span>
+        <a id="server-status-badge" class="brand-status" href="members.html" aria-live="polite">
+          <span class="status-dot brand-status-dot" aria-hidden="true"></span>
           <span id="server-status-text">Checking…</span>
-        </span>
+        </a>
       </div>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
 
@@ -1065,6 +1073,7 @@
       © 2026 Pinnacle SMP. All rights reserved.
     </div>
   </footer>
+  <script src="assets/server-status.js"></script>
   <script>
     (() => {
       const header = document.querySelector(".site-header");
@@ -1104,8 +1113,8 @@
     (() => {
       const badge = document.getElementById("server-status-badge");
       const label = document.getElementById("server-status-text");
-      const statusApi = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
-      if (!badge || !label) return;
+      const statusService = window.PinnacleServerStatus;
+      if (!badge || !label || !statusService?.fetchServerStatus) return;
 
       const setOffline = () => {
         badge.classList.remove("online");
@@ -1120,18 +1129,13 @@
       };
 
       const refreshServerStatus = async () => {
-        try {
-          const response = await fetch(statusApi, { cache: "no-store" });
-          if (!response.ok) throw new Error("Bad response");
-          const data = await response.json();
-          if (!data?.online) {
-            setOffline();
-            return;
-          }
-          setOnline(Number(data.players?.online ?? 0));
-        } catch (error) {
+        const data = await statusService.fetchServerStatus();
+        if (!data.online) {
           setOffline();
+          return;
         }
+
+        setOnline(data.playersOnline);
       };
 
       refreshServerStatus();

--- a/members.html
+++ b/members.html
@@ -145,6 +145,48 @@
       transition: transform 0.15s ease, border-color 0.2s ease, background-color 0.2s ease;
     }
 
+    .member-name {
+      min-width: 0;
+      flex: 1;
+    }
+
+    .member-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-left: 10px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 108, 143, 0.42);
+      background: rgba(20, 24, 34, 0.35);
+      color: #ffd9df;
+      font-size: 0.74rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      flex-shrink: 0;
+      transition: border-color 0.25s ease, color 0.25s ease, background-color 0.25s ease;
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: #ff6c8f;
+      flex-shrink: 0;
+      transition: background-color 0.25s ease;
+    }
+
+    .member-button.online .member-status {
+      color: #237750;
+      border-color: rgba(95, 255, 156, 0.55);
+      background: rgba(239, 245, 242, 0.92);
+    }
+
+    .member-button.online .status-dot {
+      background: var(--green);
+    }
+
     .member-button:hover,
     .member-button:focus-visible {
       transform: translateY(-1px);
@@ -219,50 +261,50 @@
         <section class="member-section founding">
           <h2>Founding Members</h2>
           <ul class="member-list">
-            <li><a class="member-button" href="profiles/McCreeper1318.html">McCreeper1318</a></li>
-            <li><a class="member-button" href="profiles/JohnnyKilroy.html">JohnnyKilroy</a></li>
-            <li><a class="member-button" href="profiles/Piff.html">Piff</a></li>
-            <li><a class="member-button" href="profiles/Jeff.html">Jeff</a></li>
+            <li><a class="member-button" href="profiles/McCreeper1318.html" data-username="McCreeper1318"><span class="member-name">McCreeper1318</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/JohnnyKilroy.html" data-username="JohnnyKilroy"><span class="member-name">JohnnyKilroy</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Piff.html" data-username="Piff"><span class="member-name">Piff</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Jeff.html" data-username="Jeff"><span class="member-name">Jeff</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
           </ul>
         </section>
 
         <section class="member-section legacy">
           <h2>Legacy Members</h2>
           <ul class="member-list">
-            <li><a class="member-button" href="profiles/BeansUniverse.html">BeansUniverse</a></li>
-            <li><a class="member-button" href="profiles/MoeBe10.html">MoeBe10</a></li>
-            <li><a class="member-button" href="profiles/IronArmored.html">rad1709 (IronArmored)</a></li>
-            <li><a class="member-button" href="profiles/GodlyCris.html">GodlyCris</a></li>
+            <li><a class="member-button" href="profiles/BeansUniverse.html" data-username="BeansUniverse"><span class="member-name">BeansUniverse</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/MoeBe10.html" data-username="MoeBe10"><span class="member-name">MoeBe10</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/IronArmored.html" data-username="IronArmored"><span class="member-name">rad1709 (IronArmored)</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/GodlyCris.html" data-username="GodlyCris"><span class="member-name">GodlyCris</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
           </ul>
         </section>
 
         <section class="member-section full">
           <h2>Full Members</h2>
           <ul class="member-list">
-            <li><a class="member-button" href="profiles/Atlaskytan.html">Atlaskytan</a></li>
-            <li><a class="member-button" href="profiles/BadFiction.html">BadFiction</a></li>
-            <li><a class="member-button" href="profiles/pinapple_pete.html">pinapple_pete</a></li>
-            <li><a class="member-button" href="profiles/mermaidxellie.html">mermaidxellie</a></li>
-            <li><a class="member-button" href="profiles/misfiired.html">misfiired</a></li>
-            <li><a class="member-button" href="profiles/notnownotnever.html">notnownotnever</a></li>
-            <li><a class="member-button" href="profiles/Poplare.html">Poplare (Shiny)</a></li>
-            <li><a class="member-button" href="profiles/Beslife.html">Beslife</a></li>
-            <li><a class="member-button" href="profiles/nicholattee.html">nicholattee (Nic/Duck)</a></li>
-            <li><a class="member-button" href="profiles/StirfrySurprise.html">StirfrySurprise</a></li>
-            <li><a class="member-button" href="profiles/kylethecaver.html">kylethecaver</a></li>
-            <li><a class="member-button" href="profiles/Kananers.html">Kananers</a></li>
-            <li><a class="member-button" href="profiles/BACONcuzBACON.html">BACONcuzBACON</a></li>
-            <li><a class="member-button" href="profiles/Aryamii.html">Aryamii</a></li>
-            <li><a class="member-button" href="profiles/t0w0fu.html">t0w0fu</a></li>
-            <li><a class="member-button" href="profiles/BraneFX.html">BraneFX</a></li>
-            <li><a class="member-button" href="profiles/Kelly_E.html">Kelly_E</a></li>
+            <li><a class="member-button" href="profiles/Atlaskytan.html" data-username="Atlaskytan"><span class="member-name">Atlaskytan</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/BadFiction.html" data-username="BadFiction"><span class="member-name">BadFiction</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/pinapple_pete.html" data-username="pinapple_pete"><span class="member-name">pinapple_pete</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/mermaidxellie.html" data-username="mermaidxellie"><span class="member-name">mermaidxellie</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/misfiired.html" data-username="misfiired"><span class="member-name">misfiired</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/notnownotnever.html" data-username="notnownotnever"><span class="member-name">notnownotnever</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Poplare.html" data-username="Poplare"><span class="member-name">Poplare (Shiny)</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Beslife.html" data-username="Beslife"><span class="member-name">Beslife</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/nicholattee.html" data-username="nicholattee"><span class="member-name">nicholattee (Nic/Duck)</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/StirfrySurprise.html" data-username="StirfrySurprise"><span class="member-name">StirfrySurprise</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/kylethecaver.html" data-username="kylethecaver"><span class="member-name">kylethecaver</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Kananers.html" data-username="Kananers"><span class="member-name">Kananers</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/BACONcuzBACON.html" data-username="BACONcuzBACON"><span class="member-name">BACONcuzBACON</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Aryamii.html" data-username="Aryamii"><span class="member-name">Aryamii</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/t0w0fu.html" data-username="t0w0fu"><span class="member-name">t0w0fu</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/BraneFX.html" data-username="BraneFX"><span class="member-name">BraneFX</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
+            <li><a class="member-button" href="profiles/Kelly_E.html" data-username="Kelly_E"><span class="member-name">Kelly_E</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
           </ul>
         </section>
 
         <section class="member-section new">
           <h2>New Members</h2>
           <ul class="member-list">
-            <li><a class="member-button" href="profiles/NateOnGuitar.html">NateOnGuitar</a></li>
+            <li><a class="member-button" href="profiles/NateOnGuitar.html" data-username="NateOnGuitar"><span class="member-name">NateOnGuitar</span><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span></a></li>
           </ul>
         </section>
       </div>
@@ -276,5 +318,37 @@
       </section>
     </section>
   </main>
+  <script src="assets/server-status.js"></script>
+  <script>
+    (() => {
+      const statusService = window.PinnacleServerStatus;
+      const memberButtons = document.querySelectorAll(".member-button[data-username]");
+      if (!statusService?.fetchServerStatus || !memberButtons.length) return;
+
+      const setMemberState = (button, isOnline) => {
+        button.classList.toggle("online", isOnline);
+        const label = button.querySelector(".member-status-label");
+        if (label) {
+          label.textContent = isOnline ? "Online" : "Offline";
+        }
+      };
+
+      const applyMemberStatuses = (onlinePlayers) => {
+        const onlineSet = new Set(onlinePlayers.map((player) => player.toLowerCase()));
+
+        memberButtons.forEach((button) => {
+          const username = String(button.dataset.username ?? "").toLowerCase();
+          setMemberState(button, username !== "" && onlineSet.has(username));
+        });
+      };
+
+      const refreshMemberStatuses = async () => {
+        const data = await statusService.fetchServerStatus();
+        applyMemberStatuses(data.online ? data.onlinePlayers : []);
+      };
+
+      refreshMemberStatuses();
+    })();
+  </script>
 </body>
 </html>

--- a/profiles/Aryamii.html
+++ b/profiles/Aryamii.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Aryamii.png" alt="Aryamii Minecraft player head" />
       <div>
         <h1 class="name">Aryamii</h1>
+        <div class="profile-status offline" data-username="Aryamii">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Atlaskytan.html
+++ b/profiles/Atlaskytan.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Atlaskytan.png" alt="Atlaskytan Minecraft player head" />
       <div>
         <h1 class="name">Atlaskytan</h1>
+        <div class="profile-status offline" data-username="Atlaskytan">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -74,5 +78,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/BACONcuzBACON.html
+++ b/profiles/BACONcuzBACON.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/BACONcuzBACON.png" alt="BACONcuzBACON Minecraft player head" />
       <div>
         <h1 class="name">BACONcuzBACON</h1>
+        <div class="profile-status offline" data-username="BACONcuzBACON">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/BadFiction.html
+++ b/profiles/BadFiction.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/BadFiction.png" alt="BadFiction Minecraft player head" />
       <div>
         <h1 class="name">BadFiction</h1>
+        <div class="profile-status offline" data-username="BadFiction">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -78,5 +82,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/BeansUniverse.html
+++ b/profiles/BeansUniverse.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/BeansUniverse.png" alt="BeansUniverse Minecraft player head" />
       <div>
         <h1 class="name">BeansUniverse</h1>
+        <div class="profile-status offline" data-username="BeansUniverse">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -76,5 +80,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Beslife.html
+++ b/profiles/Beslife.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Beslife.png" alt="Beslife Minecraft player head" />
       <div>
         <h1 class="name">Beslife</h1>
+        <div class="profile-status offline" data-username="Beslife">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -74,5 +78,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/BraneFX.html
+++ b/profiles/BraneFX.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/BraneFX.png" alt="BraneFX Minecraft player head" />
       <div>
         <h1 class="name">BraneFX</h1>
+        <div class="profile-status offline" data-username="BraneFX">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -74,5 +78,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/GodlyCris.html
+++ b/profiles/GodlyCris.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/GodlyCris.png" alt="GodlyCris Minecraft player head" />
       <div>
         <h1 class="name">GodlyCris</h1>
+        <div class="profile-status offline" data-username="GodlyCris">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -74,5 +78,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/IronArmored.html
+++ b/profiles/IronArmored.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/IronArmored.png" alt="rad1709 (IronArmored) Minecraft player head" />
       <div>
         <h1 class="name">rad1709 (IronArmored)</h1>
+        <div class="profile-status offline" data-username="IronArmored">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -77,5 +81,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Jeff.html
+++ b/profiles/Jeff.html
@@ -14,6 +14,10 @@
       <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
       <div>
         <h1 class="name">Jeff</h1>
+        <div class="profile-status offline" data-username="Jeff">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/JohnnyKilroy.html
+++ b/profiles/JohnnyKilroy.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/JohnnyKilroy.png" alt="JohnnyKilroy Minecraft player head" />
       <div>
         <h1 class="name">JohnnyKilroy</h1>
+        <div class="profile-status offline" data-username="JohnnyKilroy">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Kananers.html
+++ b/profiles/Kananers.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Kananers.png" alt="Kananers Minecraft player head" />
       <div>
         <h1 class="name">Kananers</h1>
+        <div class="profile-status offline" data-username="Kananers">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Kelly_E.html
+++ b/profiles/Kelly_E.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Kelly_E.png" alt="Kelly_E Minecraft player head" />
       <div>
         <h1 class="name">Kelly_E</h1>
+        <div class="profile-status offline" data-username="Kelly_E">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -75,5 +79,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/McCreeper1318.html
+++ b/profiles/McCreeper1318.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/McCreeper1318.png" alt="McCreeper1318 Minecraft player head" />
       <div>
         <h1 class="name">McCreeper1318</h1>
+        <div class="profile-status offline" data-username="McCreeper1318">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -77,5 +81,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/MoeBe10.html
+++ b/profiles/MoeBe10.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/MoeBe10.png" alt="MoeBe10 Minecraft player head" />
       <div>
         <h1 class="name">MoeBe10</h1>
+        <div class="profile-status offline" data-username="MoeBe10">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/NateOnGuitar.html
+++ b/profiles/NateOnGuitar.html
@@ -14,6 +14,10 @@
       <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
       <div>
         <h1 class="name">NateOnGuitar</h1>
+        <div class="profile-status offline" data-username="NateOnGuitar">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Piff.html
+++ b/profiles/Piff.html
@@ -14,6 +14,10 @@
       <div class="head-placeholder">Player head image pending<br />(add to /assets/player_heads)</div>
       <div>
         <h1 class="name">Piff</h1>
+        <div class="profile-status offline" data-username="Piff">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -75,5 +79,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/Poplare.html
+++ b/profiles/Poplare.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/Poplare.png" alt="Poplare (Shiny) Minecraft player head" />
       <div>
         <h1 class="name">Poplare (Shiny)</h1>
+        <div class="profile-status offline" data-username="Poplare">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/StirfrySurprise.html
+++ b/profiles/StirfrySurprise.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/StirfrySurprise.png" alt="StirfrySurprise Minecraft player head" />
       <div>
         <h1 class="name">StirfrySurprise</h1>
+        <div class="profile-status offline" data-username="StirfrySurprise">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/kylethecaver.html
+++ b/profiles/kylethecaver.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/kylethecaver.png" alt="kylethecaver Minecraft player head" />
       <div>
         <h1 class="name">kylethecaver</h1>
+        <div class="profile-status offline" data-username="kylethecaver">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/mermaidxellie.html
+++ b/profiles/mermaidxellie.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/mermaidxellie.png" alt="mermaidxellie Minecraft player head" />
       <div>
         <h1 class="name">mermaidxellie</h1>
+        <div class="profile-status offline" data-username="mermaidxellie">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -74,5 +78,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/misfiired.html
+++ b/profiles/misfiired.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/misfiired.png" alt="misfiired Minecraft player head" />
       <div>
         <h1 class="name">misfiired</h1>
+        <div class="profile-status offline" data-username="misfiired">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/nicholattee.html
+++ b/profiles/nicholattee.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/nicholattee.png" alt="nicholattee (Nic/Duck) Minecraft player head" />
       <div>
         <h1 class="name">nicholattee (Nic/Duck)</h1>
+        <div class="profile-status offline" data-username="nicholattee">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/notnownotnever.html
+++ b/profiles/notnownotnever.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/notnownotnever.png" alt="notnownotnever Minecraft player head" />
       <div>
         <h1 class="name">notnownotnever</h1>
+        <div class="profile-status offline" data-username="notnownotnever">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/pinapple_pete.html
+++ b/profiles/pinapple_pete.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/pinapple_pete.png" alt="pinapple_pete Minecraft player head" />
       <div>
         <h1 class="name">pinapple_pete</h1>
+        <div class="profile-status offline" data-username="pinapple_pete">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>

--- a/profiles/profile-status.js
+++ b/profiles/profile-status.js
@@ -1,0 +1,29 @@
+(() => {
+  const statusService = window.PinnacleServerStatus;
+  const badge = document.querySelector('.profile-status[data-username]');
+  if (!statusService?.fetchServerStatus || !badge) return;
+
+  const label = badge.querySelector('.profile-status-label');
+
+  const setOnlineState = (isOnline) => {
+    badge.classList.toggle('online', isOnline);
+    badge.classList.toggle('offline', !isOnline);
+    if (label) {
+      label.textContent = isOnline ? 'Online' : 'Offline';
+    }
+  };
+
+  const refreshProfileStatus = async () => {
+    const username = String(badge.dataset.username ?? '').toLowerCase();
+    if (!username) {
+      setOnlineState(false);
+      return;
+    }
+
+    const data = await statusService.fetchServerStatus();
+    const onlinePlayers = new Set((data.online ? data.onlinePlayers : []).map((player) => String(player).toLowerCase()));
+    setOnlineState(onlinePlayers.has(username));
+  };
+
+  refreshProfileStatus();
+})();

--- a/profiles/profile.css
+++ b/profiles/profile.css
@@ -78,6 +78,37 @@ body {
   margin: 8px 0 0;
   color: var(--muted);
 }
+
+.profile-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 108, 143, 0.42);
+  background: rgba(20, 24, 34, 0.35);
+  color: #ffd9df;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #ff6c8f;
+  flex-shrink: 0;
+}
+.profile-status.online {
+  color: #237750;
+  border-color: rgba(95, 255, 156, 0.55);
+  background: rgba(239, 245, 242, 0.92);
+}
+.profile-status.online .status-dot {
+  background: #7affb4;
+}
 .grid {
   margin-top: 18px;
   display: grid;

--- a/profiles/t0w0fu.html
+++ b/profiles/t0w0fu.html
@@ -14,6 +14,10 @@
       <img class="player-head" src="../assets/player_heads/t0w0fu.png" alt="t0w0fu Minecraft player head" />
       <div>
         <h1 class="name">t0w0fu</h1>
+        <div class="profile-status offline" data-username="t0w0fu">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
         <p class="tagline">Pinnacle SMP Member Profile</p>
       </div>
     </section>
@@ -73,5 +77,7 @@
 
     <p class="footnote"></p>
   </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a centralized client-side service to fetch Pinnacle SMP server status and expose player lists for UI components.
- Surface real-time online/offline state in the site header, members listing, and individual member profile pages to improve community awareness.

### Description
- Add `assets/server-status.js` which fetches `https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun` and exposes `window.PinnacleServerStatus.fetchServerStatus()` returning normalized `{ online, playersOnline, onlinePlayers }` data.
- Update `index.html` to make the header server badge a link, include the new service, and replace inline fetch logic with calls to the shared status service to update the badge text and styles on a 30s interval.
- Update `members.html` to add structured member elements (`.member-status`, `.status-dot`, `.member-status-label`, and `data-username`) and include a script that marks members online based on the service's player list.
- Add `profiles/profile-status.js` and updates to many `profiles/*.html` files to insert a per-profile `.profile-status` widget, include the status service and `profile-status.js`, and extend `profiles/profile.css` with styling for online/offline states.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ca0d8b38832fa2976e810f371822)