### PR TITLE
Fix member online/offline status matching (support object-based player entries)

### DIFF
--- a/members.html
+++ b/members.html
@@ -364,7 +364,15 @@
       };
 
       const applyMemberStatuses = (onlinePlayers) => {
-        const onlineSet = new Set(onlinePlayers.map((player) => normalizeUsername(player)).filter(Boolean));
+        const onlineSet = new Set(
+          (Array.isArray(onlinePlayers) ? onlinePlayers : [])
+            .map((player) => {
+              if (typeof player === "string") return normalizeUsername(player);
+              if (player && typeof player === "object") return normalizeUsername(player.name);
+              return "";
+            })
+            .filter(Boolean)
+        );
 
         memberButtons.forEach((button) => {
           const usernames = getCandidateUsernames(button);
@@ -373,8 +381,13 @@
       };
 
       const refreshMemberStatuses = async () => {
-        const data = await statusService.fetchServerStatus();
-        applyMemberStatuses(data.onlinePlayers || []);
+        try {
+          const data = await statusService.fetchServerStatus();
+          applyMemberStatuses(data?.onlinePlayers || []);
+        } catch (error) {
+          console.error("Failed to refresh member statuses.", error);
+          applyMemberStatuses([]);
+        }
       };
 
       refreshMemberStatuses();


### PR DESCRIPTION
### Motivation
- The members page failed to mark online players when the server returned player objects like `{ name: "Kelly_E", uuid: "..." }` because the code attempted to normalize the entire object instead of the `name` property. 
- The intent is to support both string lists and object lists from the server while preserving existing username normalization and alias matching.

### Description
- In `members.html` updated `applyMemberStatuses` to build `onlineSet` by handling both string entries and object entries (using `player` directly for strings and `player.name` for objects) before normalization. 
- Wrapped the async `refreshMemberStatuses` call in `try/catch`, logging an explanatory `console.error` on failure and falling back to applying an empty online list to preserve graceful behavior. 
- Kept all existing candidate username extraction, alias handling, DOM structure, styling, and member listings unchanged; only the status-matching script block was modified.

### Testing
- Verified the patch by inspecting the updated script block in `members.html` with `git diff -- members.html` and `nl -ba members.html | sed -n '356,405p'`, which show the new mapping and `try/catch` logic. 
- No automated unit tests were added for this UI script; there is no test-suite run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d372e1ec832f87ef2d00c09eab84)