### PR TITLE
Make member status refresh resilient to varied payloads and failures

### DIFF
--- a/members.html
+++ b/members.html
@@ -364,7 +364,15 @@
       };
 
       const applyMemberStatuses = (onlinePlayers) => {
-        const onlineSet = new Set(onlinePlayers.map((player) => normalizeUsername(player)).filter(Boolean));
+        const onlineSet = new Set(
+          (Array.isArray(onlinePlayers) ? onlinePlayers : [])
+            .map((player) => {
+              if (typeof player === "string") return normalizeUsername(player);
+              if (player && typeof player === "object") return normalizeUsername(player.name);
+              return "";
+            })
+            .filter(Boolean)
+        );
 
         memberButtons.forEach((button) => {
           const usernames = getCandidateUsernames(button);
@@ -373,8 +381,14 @@
       };
 
       const refreshMemberStatuses = async () => {
-        const data = await statusService.fetchServerStatus();
-        applyMemberStatuses(data.onlinePlayers || []);
+        try {
+          const data = await statusService.fetchServerStatus();
+          const onlinePlayers = data?.onlinePlayers || data?.players?.list || [];
+          applyMemberStatuses(onlinePlayers);
+        } catch (error) {
+          console.error("Failed to refresh member statuses.", error);
+          applyMemberStatuses([]);
+        }
       };
 
       refreshMemberStatuses();


### PR DESCRIPTION
### Motivation
- Ensure the members list UI correctly detects online players when the server returns different payload shapes or item types. 
- Prevent uncaught errors during status refresh from breaking the page and provide a safe offline fallback.

### Description
- Update `applyMemberStatuses` to accept non-array `onlinePlayers` inputs and normalize items that may be strings or objects with a `name` property. 
- Change `refreshMemberStatuses` to look for `data.onlinePlayers` or `data.players.list` and default to an empty array when missing. 
- Wrap the fetch in a `try/catch`, log errors via `console.error`, and call `applyMemberStatuses([])` on failure.

### Testing
- Ran the frontend unit test suite with `npm test` and all tests passed. 
- Ran the linter with `npm run lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d372e1ec832f87ef2d00c09eab84)