### PR TITLE
Preserve online player names from mcsrvstat.us API in server-status

### DIFF
--- a/assets/server-status.js
+++ b/assets/server-status.js
@@ -2,12 +2,24 @@
   const STATUS_API = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
 
   const normalizePlayerList = (listValue) => {
+    const getPlayerName = (player) => {
+      if (typeof player === "string") return player;
+      if (player && typeof player === "object" && typeof player.name === "string") {
+        return player.name;
+      }
+      return null;
+    };
+
     if (Array.isArray(listValue)) {
-      return listValue.filter((player) => typeof player === "string");
+      return listValue
+        .map(getPlayerName)
+        .filter((playerName) => typeof playerName === "string");
     }
 
     if (listValue && typeof listValue === "object") {
-      return Object.values(listValue).filter((player) => typeof player === "string");
+      return Object.values(listValue)
+        .map(getPlayerName)
+        .filter((playerName) => typeof playerName === "string");
     }
 
     return [];


### PR DESCRIPTION
### Motivation
- Fix lost player names that caused the Members page to display everyone as Offline by handling API responses where `players.list` entries can be objects like `{ name, uuid }` as well as plain strings.

### Description
- Update `normalizePlayerList` in `assets/server-status.js` to use a `getPlayerName` extractor that returns a string for either string entries or object entries with a `.name`, apply it to arrays and object-like collections, and return an array of usernames while leaving `fetchServerStatus` behavior and online/offline fallback logic unchanged.

### Testing
- Ran `node --check assets/server-status.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d5f61c88832f9de8ccc62e1bc9c2)