### PR TITLE
Normalize server player entries and simplify members online-status refresh

### DIFF
--- a/assets/server-status.js
+++ b/assets/server-status.js
@@ -2,12 +2,24 @@
   const STATUS_API = "https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun";
 
   const normalizePlayerList = (listValue) => {
+    const getPlayerName = (player) => {
+      if (typeof player === "string") return player;
+      if (player && typeof player === "object" && typeof player.name === "string") {
+        return player.name;
+      }
+      return null;
+    };
+
     if (Array.isArray(listValue)) {
-      return listValue.filter((player) => typeof player === "string");
+      return listValue
+        .map(getPlayerName)
+        .filter((playerName) => typeof playerName === "string");
     }
 
     if (listValue && typeof listValue === "object") {
-      return Object.values(listValue).filter((player) => typeof player === "string");
+      return Object.values(listValue)
+        .map(getPlayerName)
+        .filter((playerName) => typeof playerName === "string");
     }
 
     return [];

--- a/members.html
+++ b/members.html
@@ -322,81 +322,47 @@
   <script>
     (() => {
       const statusService = window.PinnacleServerStatus;
-      const memberButtons = document.querySelectorAll(".member-button[data-username]");
+      const memberButtons = document.querySelectorAll('.member-button[data-username]');
       if (!statusService?.fetchServerStatus || !memberButtons.length) return;
 
-      const normalizeUsername = (value) => String(value ?? "")
+      const normalizeUsername = (value) => String(value ?? '')
         .toLowerCase()
-        .replace(/[^a-z0-9_]/g, "");
+        .replace(/[^a-z0-9_]/g, '');
 
       const getCandidateUsernames = (button) => {
-        const candidates = new Set();
-        const fromData = String(button.dataset.usernames || button.dataset.username || "")
-          .split(",")
-          .map((entry) => normalizeUsername(entry))
-          .filter(Boolean);
-
-        fromData.forEach((username) => candidates.add(username));
-
-        const nameText = button.querySelector(".member-name")?.textContent ?? "";
-        const baseText = nameText.replace(/\(.*?\)/g, " ");
-        baseText.split(/\s+/).forEach((entry) => {
-          const username = normalizeUsername(entry);
-          if (username) candidates.add(username);
-        });
-
-        const aliases = [...nameText.matchAll(/\(([^)]+)\)/g)]
-          .flatMap((match) => match[1].split(/[\/,]/));
-        aliases.forEach((entry) => {
-          const username = normalizeUsername(entry);
-          if (username) candidates.add(username);
-        });
+        const candidates = new Set(
+          String(button.dataset.usernames || button.dataset.username || '')
+            .split(',')
+            .map((entry) => normalizeUsername(entry))
+            .filter(Boolean)
+        );
 
         return [...candidates];
       };
 
       const setMemberState = (button, isOnline) => {
-        button.classList.toggle("online", isOnline);
-        const label = button.querySelector(".member-status-label");
+        button.classList.toggle('online', isOnline);
+        const label = button.querySelector('.member-status-label');
         if (label) {
-          label.textContent = isOnline ? "Online" : "Offline";
+          label.textContent = isOnline ? 'Online' : 'Offline';
         }
-      };
-
-      const applyMemberStatuses = (onlinePlayers) => {
-        const onlineSet = new Set(
-          (Array.isArray(onlinePlayers) ? onlinePlayers : [])
-            .map((player) => {
-              if (typeof player === "string") return normalizeUsername(player);
-              if (player && typeof player === "object") return normalizeUsername(player.name);
-              return "";
-            })
-            .filter(Boolean)
-        );
-
-        memberButtons.forEach((button) => {
-          const usernames = getCandidateUsernames(button);
-          setMemberState(button, usernames.some((username) => onlineSet.has(username)));
-        });
       };
 
       const refreshMemberStatuses = async () => {
-        try {
-          const data = await statusService.fetchServerStatus();
-<<<<<<< codex/fix-online/offline-status-logic-on-members-page
-          const onlinePlayers = data?.onlinePlayers || data?.players?.list || [];
-          applyMemberStatuses(onlinePlayers);
-=======
-          applyMemberStatuses(data?.onlinePlayers || []);
->>>>>>> main
-        } catch (error) {
-          console.error("Failed to refresh member statuses.", error);
-          applyMemberStatuses([]);
-        }
+        const data = await statusService.fetchServerStatus();
+        const onlinePlayers = new Set((data.onlinePlayers || [])
+          .map((player) => normalizeUsername(player))
+          .filter(Boolean));
+
+        memberButtons.forEach((button) => {
+          const usernames = getCandidateUsernames(button);
+          setMemberState(button, usernames.some((username) => onlinePlayers.has(username)));
+        });
       };
 
       refreshMemberStatuses();
     })();
   </script>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure player lists returned by the status API are normalized when items may be strings or objects with a `name` property.  
- Simplify and correct the members page logic that matched online players to member buttons and remove a broken/merge-conflicted code path.  
- Clean up small style inconsistencies and remove leftover merge markers in `members.html`.

### Description
- In `assets/server-status.js` added a `getPlayerName` helper and updated `normalizePlayerList` to extract names from string entries and objects with a `name` field.  
- In `members.html` simplified `getCandidateUsernames` to derive candidates from `data-usernames`/`data-username` only, removing complex DOM parsing and alias handling.  
- Replaced the previous `applyMemberStatuses` flow with a single `refreshMemberStatuses` that fetches status via `statusService.fetchServerStatus()` and builds a normalized set of online usernames for matching.  
- Minor style cleanups such as using single quotes consistently and removal of leftover merge conflict artifacts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d5f61c88832f9de8ccc62e1bc9c2)