### PR TITLE
Add shared top navigation to secondary pages and remove back links

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -110,12 +110,147 @@
       text-decoration: none;
       font-weight: 700;
     }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
-  <main class="container">
-    <a href="index.html#about-us" class="back-link">← Back to home</a>
 
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
     <section class="panel">
       <center><img class="hero-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP logo" /></center>
       <h1>Who we are…</h1>
@@ -134,5 +269,30 @@ Currently Pinnacle is on its 12th season and has no current plans on starting se
       <a class="cta" href="index.html#apply-here">Apply to Join</a>
     </section>
   </main>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -89,9 +89,146 @@
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
     .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
     <div class="card">
       <h1>Ban Appeal</h1>
@@ -171,5 +308,30 @@
       window.open(url, "_blank", "noopener");
     });
   </script>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/contact-us.html
+++ b/contact-us.html
@@ -84,9 +84,146 @@
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
     .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
     <div class="card">
       <h1>Contact Us</h1>
@@ -161,5 +298,30 @@
       window.open(url, "_blank", "noopener");
     });
   </script>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/members.html
+++ b/members.html
@@ -247,12 +247,147 @@
         column-count: 1;
       }
     }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
-  <main class="container">
-    <a href="index.html#join" class="back-link">← Back to home</a>
 
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
     <section class="panel">
       <h1>Pinnacle SMP Members</h1>
       <p class="intro">Meet the current roster of Pinnacle SMP members, grouped by membership status.</p>
@@ -361,6 +496,31 @@
       };
 
       refreshMemberStatuses();
+    })();
+  </script>
+
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
     })();
   </script>
 

--- a/news.html
+++ b/news.html
@@ -279,18 +279,146 @@
       .article-header,
       .article-content { padding-left: 18px; padding-right: 18px; }
     }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+  
   <header class="site-header">
-    <div class="container nav-wrap">
+    <div class="nav-wrap">
       <a href="index.html#home" class="brand">
         <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
-      <a class="btn" href="index.html#news">← Back to Home News</a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
+
 
   <main>
     <section class="hero">
@@ -437,5 +565,30 @@
   <footer class="site-footer">
     <div class="container footer-content">© 2026 Pinnacle SMP. All rights reserved.</div>
   </footer>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -84,9 +84,146 @@
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
     .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
     <div class="card">
       <h1>Plugin Suggestions</h1>
@@ -165,5 +302,30 @@
       window.open(url, "_blank", "noopener");
     });
   </script>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -153,12 +153,147 @@
     .medal.gold { color: var(--gold); }
     .medal.silver { color: var(--silver); }
     .medal.bronze { color: var(--bronze); }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
-  <main class="container">
-    <a href="index.html" class="back-link">← Back to home</a>
 
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
     <section class="section">
       <h1>Current Server Tournament</h1>
       <div class="frame-wrap">
@@ -252,5 +387,30 @@
       </div>
     </section>
   </main>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/vote-history.html
+++ b/vote-history.html
@@ -215,11 +215,147 @@
       .timeline { padding-left: 18px; }
       .vote::before { left: -18px; }
     }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
-    <a href="index.html#join" class="back-link">← Back to home</a>
     <h1>Pinnacle SMP Vote History</h1>
     <p class="subtitle">
       A running timeline of community decisions that shaped Season 11 and beyond. Every poll captures how players weighed updates,
@@ -387,5 +523,30 @@
       </article>
     </section>
   </main>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -104,9 +104,146 @@
     }
     .btn-primary { background: linear-gradient(135deg, var(--green), var(--cyan)); color: var(--text); }
     .btn-secondary { background: var(--btn-secondary-bg); color: var(--text); }
+  
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
+
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
     <div class="card">
       <h1>Whitelist Application</h1>
@@ -212,5 +349,30 @@
       window.open(url, "_blank", "noopener");
     });
   </script>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a consistent, site-wide top navigation across secondary pages so users can reach primary sections (Home, Server News, Events, Server Rules, Join) without relying on contextual "back" links.  
- Remove redundant in-page back links that conflict with the unified header and streamline the header on the news page.

### Description
- Injected a shared `.site-header` markup (brand, menu toggle, and nav links) into: `about-us.html`, `members.html`, `vote-history.html`, `tournament-standings.html`, `contact-us.html`, `ban-appeal.html`, `plugin-suggestions.html`, `whitelist-application.html`, and `news.html`.  
- Added CSS for the header, nav layout, responsive behavior, and `.nav-link` styles to each updated page's `<style>` block so the header matches the main site styling.  
- Appended a small JS module to each updated page to support the mobile menu toggle and auto-close behavior when navigation links are clicked.  
- Removed the inline "Back to home" anchors from `about-us.html`, `members.html`, `vote-history.html`, and `tournament-standings.html`, and removed the `Back to Home News` button from `news.html`.

### Testing
- Verified the header insertion and link text with a ripgrep check for the header element across updated pages using `rg -n "<header class=\"site-header\""` which found the new header in all target files.  
- Confirmed that previous back-link strings are no longer present with `rg -n "Back to home|Back to Home News"` against the modified pages and returned no matches.  
- Ran a local file-diff inspection to confirm the expected HTML/CSS/JS blocks were added to the nine target files and that no other files were altered.  
- No automated browser rendering or visual snapshot tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dba24a20832fa976ebe7ef0a1d9a)