### PR TITLE
Remove 'Back to Home' buttons and add top nav to FAQ

### DIFF
--- a/ban-appeal.html
+++ b/ban-appeal.html
@@ -271,7 +271,6 @@
 
         <div class="actions">
           <button class="btn btn-primary" type="submit">Submit to GitHub</button>
-          <a class="btn btn-secondary" href="index.html">Back to Home</a>
         </div>
       </form>
     </div>

--- a/contact-us.html
+++ b/contact-us.html
@@ -263,7 +263,6 @@
 
         <div class="actions">
           <button class="btn btn-primary" type="submit">Submit to GitHub</button>
-          <a class="btn btn-secondary" href="index.html">Back to Home</a>
         </div>
       </form>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -136,9 +136,145 @@
       background: var(--btn-secondary-bg);
       color: var(--text);
     }
+
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
+    }
+
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
   </style>
 </head>
 <body>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
   <main class="container">
     <section class="card">
       <h1>Frequently Asked Questions</h1>
@@ -237,9 +373,33 @@
 
       <div class="actions">
         <a class="btn btn-primary" href="https://discord.gg/pinnaclesmp" target="_blank" rel="noopener noreferrer">Join Discord</a>
-        <a class="btn btn-secondary" href="index.html">Back to Home</a>
       </div>
     </section>
   </main>
+
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>

--- a/plugin-suggestions.html
+++ b/plugin-suggestions.html
@@ -265,7 +265,6 @@
 
         <div class="actions">
           <button class="btn btn-primary" type="submit">Submit to GitHub</button>
-          <a class="btn btn-secondary" href="index.html">Back to Home</a>
         </div>
       </form>
     </div>

--- a/whitelist-application.html
+++ b/whitelist-application.html
@@ -307,7 +307,6 @@
 
         <div class="actions">
           <button class="btn btn-primary" type="submit">Submit to GitHub</button>
-          <a class="btn btn-secondary" href="index.html">Back to Home</a>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Remove the redundant bottom “Back to Home” CTA from several form/info pages to simplify actions and avoid duplicate navigation.  
- Add the same sticky top navigation used by the form pages to the FAQ so the FAQ layout matches the site header pattern.  
- Ensure the FAQ is responsive by including the mobile menu toggle behavior that other pages already use.  

### Description
- Removed the bottom `<a class="btn btn-secondary" href="index.html">Back to Home</a>` link from `faq.html`, `contact-us.html`, `ban-appeal.html`, `plugin-suggestions.html`, and `whitelist-application.html`.  
- Added header markup (brand, nav links, and mobile menu button), matching CSS rules, and the mobile toggle script to `faq.html` (`.site-header`, `.menu-toggle`, `#mobile-nav` and supporting styles/scripts).  
- Kept existing CTA buttons (e.g., the primary Discord/Submit buttons) and only removed the secondary home links to preserve current form behavior.  

### Testing
- Ran `rg -n "Back to Home" faq.html contact-us.html ban-appeal.html plugin-suggestions.html whitelist-application.html` to locate instances of the removed link and confirmed none remain. (succeeded)  
- Executed `for f in faq.html contact-us.html ban-appeal.html plugin-suggestions.html whitelist-application.html; do if rg -q "Back to Home" "$f"; then echo "$f:found"; else echo "$f:ok"; fi; done` to validate all five files report `ok`. (succeeded)  
- Verified FAQ includes the new header and mobile elements with `rg -n "<header class=\"site-header\"|menu-toggle|mobile-nav" faq.html` to confirm the header markup and script presence. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dd815ee8832fb3eaf7f7773cd4a7)