### PR TITLE
Make 'Monthly Member Awards' heading black

### DIFF
--- a/members.html
+++ b/members.html
@@ -206,7 +206,7 @@
 
     .awards-panel h2 {
       margin: 0 0 18px;
-      color: var(--gold);
+      color: #000;
       font-size: 1.35rem;
     }
 


### PR DESCRIPTION
### Motivation
- The awards heading used the theme gold variable which needed to be changed to black for better contrast on the members page.

### Description
- Updated the `.awards-panel h2` rule in `members.html` to replace `color: var(--gold)` with `color: #000` so the “Monthly Member Awards” heading renders in black.

### Testing
- Verified the change by printing the updated lines with `nl -ba members.html | sed -n '204,212p'` and confirmed the `.awards-panel h2` rule now shows `color: #000`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7deee2644832f99583209b496ebeb)