### PR TITLE
Update About Season 12 header navigation

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -175,6 +175,7 @@
     }
 
     li + li { margin-top: 6px; }
+    .site-nav li + li { margin-top: 0; }
     @media (max-width: 860px) {
       .nav-wrap {
         min-height: unset;

--- a/about-season-12.html
+++ b/about-season-12.html
@@ -56,12 +56,89 @@
       backdrop-filter: blur(8px);
     }
 
-    .back-link {
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: var(--nav-bg);
+      border-bottom: 1px solid var(--btn-secondary-bg);
+    }
+
+    .nav-wrap {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 0 auto;
+      min-height: 82px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
       display: inline-flex;
-      margin-bottom: 20px;
-      color: var(--cyan);
-      font-weight: 700;
+      align-items: center;
+      gap: 12px;
+      color: var(--text);
       text-decoration: none;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .brand-logo {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      flex-shrink: 0;
+    }
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(141, 181, 255, 0.34);
+      background: var(--btn-secondary-bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .site-nav ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      border: 1px solid rgba(122, 162, 255, 0.22);
+      background: rgba(122, 162, 255, 0.11);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 700;
+      transition: 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(95, 255, 156, 0.42);
+      background: var(--btn-secondary-hover);
+      outline: none;
     }
 
     .panel {
@@ -98,12 +175,58 @@
     }
 
     li + li { margin-top: 6px; }
+    @media (max-width: 860px) {
+      .nav-wrap {
+        min-height: unset;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      .site-nav {
+        width: 100%;
+        display: none;
+      }
+
+      .site-header.nav-open .site-nav {
+        display: block;
+      }
+
+      .site-nav ul {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-link {
+        width: 100%;
+      }
+    }
   </style>
 </head>
 <body>
-  <main class="container">
-    <a href="index.html" class="back-link">← Back to home</a>
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a href="index.html#home" class="brand">
+        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <span>Pinnacle SMP</span>
+      </a>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
+      <nav class="site-nav" id="mobile-nav" aria-label="Main navigation">
+        <ul>
+          <li><a class="nav-link" href="index.html#home">Home</a></li>
+          <li><a class="nav-link" href="index.html#news">Server News</a></li>
+          <li><a class="nav-link" href="index.html#events">Events</a></li>
+          <li><a class="nav-link" href="index.html#rules">Server Rules</a></li>
+          <li><a class="nav-link" href="index.html#join">Join</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
+  <main class="container">
     <section class="panel">
       <h1>Pinnacle SMP — Season 12 Overview</h1>
 
@@ -171,5 +294,29 @@
       </p>
     </section>
   </main>
+  <script>
+    (() => {
+      const header = document.querySelector('.site-header');
+      const toggle = document.querySelector('.menu-toggle');
+      const nav = document.getElementById('mobile-nav');
+      if (!header || !toggle || !nav) return;
+
+      const closeMenu = () => {
+        header.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('nav-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+
+      nav.querySelectorAll('a').forEach((link) => link.addEventListener('click', closeMenu));
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 860) closeMenu();
+      });
+    })();
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make the Season 12 page consistent with the rest of the site by replacing the isolated back link with the same top navigation used on the home page.
- Provide a responsive, accessible header so mobile users get the same menu/toggle behavior as other pages.

### Description
- Removed the `← Back to home` back-link from `about-season-12.html` and inserted a sticky top header containing the brand/logo and nav links (Home, Server News, Events, Server Rules, Join).
- Added matching CSS for `.site-header`, `.nav-wrap`, `.brand`, `.brand-logo`, `.menu-toggle`, `.site-nav` and `.nav-link` and a responsive media query for mobile behavior.
- Appended a small JavaScript snippet that implements the mobile menu toggle and closes the menu on link click or when the viewport is resized above the mobile threshold.

### Testing
- Verified the generated diff for `about-season-12.html` shows the `back-link` removal and header/nav additions, and the changes matched the intended structure (success).
- Confirmed the header CSS + mobile media query were added to the stylesheet section of `about-season-12.html` by inspecting the file contents (success).
- Confirmed the mobile menu script block was appended and contains toggle and close-on-link behavior by inspecting `about-season-12.html` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea37496ce4832f9e2c1172ee12dcb5)