### PR TITLE
Add interactive server IP pill on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1219,9 +1219,10 @@
           hiddenInput.style.left = "-9999px";
           document.body.appendChild(hiddenInput);
           hiddenInput.select();
-          document.execCommand("copy");
+          const canExecCopy = typeof document.execCommand === "function";
+          const copySucceeded = canExecCopy ? document.execCommand("copy") : false;
           document.body.removeChild(hiddenInput);
-          ipPill.classList.add("is-copied");
+          if (copySucceeded) ipPill.classList.add("is-copied");
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -402,12 +402,46 @@
       padding: 18px;
     }
 
-    .server-ip {
-      margin-top: 6px;
-      font-size: 1.15rem;
+    .server-ip-pill {
+      margin-top: 10px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 250px;
+      padding: 11px 18px;
+      border-radius: 999px;
+      border: 1px solid rgba(95, 255, 156, 0.42);
+      background: linear-gradient(180deg, rgba(225, 255, 236, 0.96), rgba(209, 250, 224, 0.96));
+      color: #1f6f49;
+      font-size: 1.02rem;
       font-weight: 800;
-      letter-spacing: 0.04em;
-      color: #237750;
+      letter-spacing: 0.03em;
+      line-height: 1.2;
+      cursor: pointer;
+      box-shadow: 0 8px 20px rgba(61, 114, 84, 0.12);
+      transition: color 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+    }
+
+    .server-ip-pill .hover-label {
+      display: none;
+    }
+
+    .server-ip-pill:hover,
+    .server-ip-pill:focus-visible {
+      color: #0f5f37;
+      border-color: rgba(95, 255, 156, 0.85);
+      box-shadow: 0 0 0 1px rgba(95, 255, 156, 0.55), 0 0 22px rgba(95, 255, 156, 0.65);
+      transform: translateY(-1px);
+    }
+
+    .server-ip-pill:hover .default-label,
+    .server-ip-pill:focus-visible .default-label {
+      display: none;
+    }
+
+    .server-ip-pill:hover .hover-label,
+    .server-ip-pill:focus-visible .hover-label {
+      display: inline;
     }
 
     .status-grid {
@@ -767,8 +801,9 @@
         padding: 12px 14px;
       }
 
-      .server-ip {
+      .server-ip-pill {
         font-size: 1rem;
+        min-width: 100%;
       }
     }
   </style>
@@ -822,7 +857,10 @@
             <div class="tag">26.1.2</div> <div class="tag">Survival</div> <div class="tag">Whitelisted</div>
             <h3 style="margin-top: 12px;">Ready for your next world?</h3>
             <p class="mobile-note"></p>
-            <div class="server-ip">pinnaclesmp.mcserv.fun</div>
+            <button class="server-ip-pill" type="button" data-server-ip="pinnaclesmp.mcserv.fun" aria-label="Copy server IP address pinnaclesmp.mcserv.fun to clipboard">
+              <span class="default-label">pinnaclesmp.mcserv.fun</span>
+              <span class="hover-label">Copy This IP</span>
+            </button>
           </div>
 
           <div class="status-grid">
@@ -1146,6 +1184,29 @@
 
       refreshServerStatus();
       window.setInterval(refreshServerStatus, 30_000);
+    })();
+
+    (() => {
+      const ipPill = document.querySelector(".server-ip-pill");
+      if (!ipPill) return;
+      const serverIp = ipPill.getAttribute("data-server-ip");
+      if (!serverIp) return;
+
+      ipPill.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(serverIp);
+        } catch {
+          const hiddenInput = document.createElement("input");
+          hiddenInput.value = serverIp;
+          hiddenInput.setAttribute("aria-hidden", "true");
+          hiddenInput.style.position = "absolute";
+          hiddenInput.style.left = "-9999px";
+          document.body.appendChild(hiddenInput);
+          hiddenInput.select();
+          document.execCommand("copy");
+          document.body.removeChild(hiddenInput);
+        }
+      });
     })();
 
     (() => {

--- a/index.html
+++ b/index.html
@@ -426,6 +426,10 @@
       display: none;
     }
 
+    .server-ip-pill .copied-label {
+      display: none;
+    }
+
     .server-ip-pill:hover,
     .server-ip-pill:focus-visible {
       color: #0f5f37;
@@ -441,6 +445,16 @@
 
     .server-ip-pill:hover .hover-label,
     .server-ip-pill:focus-visible .hover-label {
+      display: inline;
+    }
+
+    .server-ip-pill.is-copied:hover .hover-label,
+    .server-ip-pill.is-copied:focus-visible .hover-label {
+      display: none;
+    }
+
+    .server-ip-pill.is-copied:hover .copied-label,
+    .server-ip-pill.is-copied:focus-visible .copied-label {
       display: inline;
     }
 
@@ -860,6 +874,7 @@
             <button class="server-ip-pill" type="button" data-server-ip="pinnaclesmp.mcserv.fun" aria-label="Copy server IP address pinnaclesmp.mcserv.fun to clipboard">
               <span class="default-label">pinnaclesmp.mcserv.fun</span>
               <span class="hover-label">Copy This IP</span>
+              <span class="copied-label">Copied!</span>
             </button>
           </div>
 
@@ -1195,6 +1210,7 @@
       ipPill.addEventListener("click", async () => {
         try {
           await navigator.clipboard.writeText(serverIp);
+          ipPill.classList.add("is-copied");
         } catch {
           const hiddenInput = document.createElement("input");
           hiddenInput.value = serverIp;
@@ -1205,8 +1221,16 @@
           hiddenInput.select();
           document.execCommand("copy");
           document.body.removeChild(hiddenInput);
+          ipPill.classList.add("is-copied");
         }
       });
+
+      const clearCopiedState = () => {
+        ipPill.classList.remove("is-copied");
+      };
+
+      ipPill.addEventListener("mouseleave", clearCopiedState);
+      ipPill.addEventListener("blur", clearCopiedState);
     })();
 
     (() => {


### PR DESCRIPTION
### Motivation
- Improve the visibility and usability of the server address by turning the static text into an interactive element that users can copy quickly.
- Provide a clear hover affordance that communicates the copy action and matches the site styling with a green glow.

### Description
- Replaced the static `div.server-ip` with a `button.server-ip-pill` that contains a default label and a hover label which reads `Copy This IP` and is revealed on hover/focus.
- Added styles for `.server-ip-pill` (pill layout, responsive sizing, green glow on hover/focus, and smooth transitions) and responsive adjustments at small widths.
- Implemented click-to-copy behavior using `navigator.clipboard.writeText(serverIp)` with a DOM-based fallback that uses a hidden input and `document.execCommand('copy')` for older browsers.
- Included an `aria-label` on the button to announce the copy action for assistive technology.

### Testing
- No automated test suite was run for this static HTML/CSS/JS change.
- Changes were verified by inspecting the updated markup, styles, and inline script in `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf09a6d88832fb50cd4c6ffb5ac5d)