### PR TITLE
Add 'New Legacy Members' announcement and homepage excerpt

### DIFF
--- a/assets/news/new-legacy-members.svg
+++ b/assets/news/new-legacy-members.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 560" role="img" aria-labelledby="title desc">
+  <title id="title">New Legacy Members Feature</title>
+  <desc id="desc">Placeholder feature image for the New Legacy Members article.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#112635"/>
+      <stop offset="100%" stop-color="#173446"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="560" fill="url(#bg)"/>
+  <g fill="#ffd66b" opacity="0.16">
+    <polygon points="180,420 280,150 380,420"/>
+    <polygon points="920,420 1020,150 1120,420"/>
+  </g>
+  <text x="80" y="280" fill="#eef3ff" font-size="64" font-family="Inter,Segoe UI,sans-serif" font-weight="700">New Legacy Members</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -916,6 +916,15 @@
         <div class="news-grid fade-in slide-up">
           <article class="card news-card hover-lift fade-in slide-up">
             <span class="tag">Announcement</span>
+            <h3>New Legacy Members</h3>
+            <p>
+              For consistently playing on the server since the beginning of Season 11, making many contributions during Season 11 and now in Season 12, and for their overall growth as Minecraft players since the start of of Season 11...
+            </p>
+            <a href="news.html#news-new-legacy-members-2026-04-24" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+          </article>
+
+          <article class="card news-card hover-lift fade-in slide-up">
+            <span class="tag">Announcement</span>
             <h3>Season 12 Has Begun</h3>
             <p>
               Season 12 is live with a brand-new world and a 3,000-block border from spawn to keep early progress fair, active, and collaborative.
@@ -930,16 +939,6 @@
               "Alpha builds for Paper 26.1.1 are now available. There is still no ETA for a stable build." - Paper Developers...
             </p>
             <a href="news.html#news-update-still-in-progress-2026-04-06" style="color: var(--cyan); font-weight: 700;">Read more →</a>
-          </article>
-
-          <article class="card news-card hover-lift fade-in slide-up">
-            <span class="tag">MBH Vote</span>
-            <h3>pinapple_pete MBH winner</h3>
-            <p>
-              pinapple_pete has won the MBH vote for April 2026! Congrats!
-              Pictures of his base will be coming soon!
-            </p>
-            <a href="news.html#news-mbh-winner-2026-04" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>
 
 

--- a/index.html
+++ b/index.html
@@ -918,7 +918,7 @@
             <span class="tag">Announcement</span>
             <h3>New Legacy Members</h3>
             <p>
-              For consistently playing on the server since the beginning of Season 11, making many contributions during Season 11 and now in Season 12, and for their overall growth as Minecraft players since the start of of Season 11...
+              For consistently playing on the server since the beginning of Season 11, making many contributions during Season 11 and now in Season 12...
             </p>
             <a href="news.html#news-new-legacy-members-2026-04-24" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>

--- a/news.html
+++ b/news.html
@@ -427,9 +427,9 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
+        <a href="#news-new-legacy-members-2026-04-24" style="color: var(--cyan); font-weight: 700;">New Legacy Members</a> •
         <a href="#news-season-12-has-begun-2026-04-14" style="color: var(--cyan); font-weight: 700;">Season 12 has begun</a> •
         <a href="#news-update-still-in-progress-2026-04-06" style="color: var(--cyan); font-weight: 700;">Update in progress</a> •
-        <a href="#news-mbh-winner-2026-04" style="color: var(--cyan); font-weight: 700;">MBH winner</a> •
         <a href="#news-ranks-system-update" style="color: var(--cyan); font-weight: 700;">Ranks update</a>
       </div>
       </div>
@@ -437,6 +437,26 @@
 
     <section>
       <div class="container news-list">
+        <article class="article" id="news-new-legacy-members-2026-04-24">
+          <header class="article-header">
+            <div class="article-meta">
+              <span class="tag">Announcement</span>
+              <time class="date" datetime="2026-04-24">April 24, 2026</time>
+            </div>
+            <h2>New Legacy Members</h2>
+          </header>
+          <img
+            class="article-image"
+            src="assets/news/new-legacy-members.svg"
+            alt="Feature image for the New Legacy Members announcement"
+          />
+          <div class="article-content">
+            <p>
+              For consistently playing on the server since the beginning of Season 11, making many contributions during Season 11 and now in Season 12, and for their overall growth as Minecraft players since the start of of Season 11, I'm excited to announce that mermaidxellie and @atlaskytan are now Legacy Members! 🥳
+            </p>
+          </div>
+        </article>
+
         <article class="article" id="news-season-12-has-begun-2026-04-14">
           <header class="article-header">
             <div class="article-meta">
@@ -505,31 +525,6 @@
               </li>
             </ul>
             <p>When there are any more updates, I will let everyone know.</p>
-          </div>
-        </article>
-
-        <article class="article" id="news-mbh-winner-2026-04">
-          <header class="article-header">
-            <div class="article-meta">
-              <span class="tag">MBH Vote</span>
-              <time class="date" datetime="2026-04-01">April 1, 2026</time>
-            </div>
-            <h2>pinapple_pete MBH winner</h2>
-          </header>
-          <img
-            class="article-image"
-            src="assets/news/mbh-winner.svg"
-            alt="Feature image for the MBH winner story"
-          />
-          <div class="article-content">
-            <p>
-              pinapple_pete has won the MBH vote for April 2026! Congrats!
-              Pictures of his base will be coming soon.
-            </p>
-            <h3>What happens next</h3>
-            <ul>
-              <li>Vote submissions for next month open in the final week of April.</li>
-            </ul>
           </div>
         </article>
 


### PR DESCRIPTION
### Motivation
- Publish a new server announcement to recognize long-term players as Legacy Members and make it discoverable from both the news archive and the homepage.
- Replace the current front-page excerpt lineup by removing the MBH winner card so the new announcement appears on the left and existing excerpts shift right.

### Description
- Added a new announcement article to `news.html` with id `news-new-legacy-members-2026-04-24` and the requested full post content and meta (Announcement / April 24, 2026). 
- Created `assets/news/new-legacy-members.svg` by reusing the same visual style as the Ranks System Update image and changing the title text to `New Legacy Members`.
- Removed the `pinapple_pete MBH winner` article block from `news.html` so it no longer appears in the archive.
- Updated `index.html` news grid to insert the new announcement excerpt as the first (left) card and shift the two existing announcement excerpts to the right, with the `Read more` links targeting `news.html#news-new-legacy-members-2026-04-24`.

### Testing
- Ran text searches with `rg -n "news-new-legacy-members|pinapple_pete MBH winner|news-mbh-winner"` to confirm the new anchor exists and MBH references were removed, which succeeded.
- Verified `assets/news/new-legacy-members.svg` was created and contains the updated title text, which succeeded.
- Inspected `news.html` and `index.html` to confirm the new article block, updated jump links, and homepage excerpt ordering, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf68fc8a4832fa3d752fc4321663f)