### PR TITLE
Add Someperso to members roster and create profile page

### DIFF
--- a/members.html
+++ b/members.html
@@ -457,6 +457,7 @@
         <a class="member-button member-card full" href="profiles/Kelly_E.html" data-username="Kelly_E"><img class="member-head" src="assets/player_heads/Kelly_E.png" alt="Kelly_E player head" /><p class="member-name">Kelly_E</p><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span><span class="member-rank">Full Member</span></a>
 
         <a class="member-button member-card new" href="profiles/NateOnGuitar.html" data-username="NateOnGuitar"><div class="member-head-placeholder">Player head image pending</div><p class="member-name">NateOnGuitar</p><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span><span class="member-rank">New Member</span></a>
+        <a class="member-button member-card new" href="profiles/Someperso.html" data-username="Someperso"><img class="member-head" src="assets/player_heads/Someperso.png" alt="Someperso player head" /><p class="member-name">Someperso</p><span class="member-status"><span class="status-dot" aria-hidden="true"></span><span class="member-status-label">Offline</span></span><span class="member-rank">New Member</span></a>
       </div>
 
       <section class="awards-panel">

--- a/profiles/Someperso.html
+++ b/profiles/Someperso.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Someperso | Pinnacle SMP Profile</title>
+  <link rel="stylesheet" href="profile.css" />
+</head>
+<body>
+  <main class="page">
+    <a class="back-link" href="../members.html">← Back to members</a>
+
+    <section class="hero">
+      <img class="player-head" src="../assets/player_heads/Someperso.png" alt="Someperso Minecraft player head" />
+      <div>
+        <h1 class="name">Someperso</h1>
+        <div class="profile-status offline" data-username="Someperso">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span class="profile-status-label">Offline</span>
+        </div>
+        <p class="tagline">Pinnacle SMP Member Profile</p>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card col-4">
+        <h2>Member Overview</h2>
+        <ul class="meta-list">
+          <li><span class="label">First Joined</span><span class="value blank">Season 12</span></li>
+          <li><span class="label">Seasons Played</span><span class="value blank">1</span></li>
+          <li><span class="label">Main Timezone</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Primary Playstyle</span><span class="value blank">Explorer</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Snapshot Stats</h2>
+        <ul class="meta-list">
+          <li><span class="label">Playtime</span><span class="value blank">0</span></li>
+          <li><span class="label">Deaths</span><span class="value blank">0</span></li>
+          <li><span class="label">Favorite Biome</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Mobs Killed</span><span class="value blank">N/A</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-4">
+        <h2>Recognition</h2>
+        <p class="note blank"></p>
+        <p class="note blank"></p>
+      </article>
+
+      <article class="card col-6">
+        <h2>Builds &amp; Projects</h2>
+        <ul class="meta-list">
+          <li><span class="label">Main Base</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Favorite Build</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Current Project</span><span class="value blank">N/A</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-6">
+        <h2>Community Highlights</h2>
+        <ul class="meta-list">
+          <li><span class="label">Known For</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Frequently Teams With</span><span class="value blank">N/A</span></li>
+          <li><span class="label">Fun Fact</span><span class="value blank">N/A</span></li>
+        </ul>
+      </article>
+
+      <article class="card col-12">
+        <h2>Quick Tags</h2>
+        <div class="chips">
+
+        </div>
+      </article>
+    </section>
+
+    <p class="footnote"></p>
+  </main>
+  <script src="../assets/server-status.js"></script>
+  <script src="profile-status.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a new member entry for Someperso to the site roster and provide a dedicated profile page populated with the requested member information.

### Description
- Inserted a New Member card for `Someperso` in `members.html` linking to `profiles/Someperso.html` and using the existing head asset at `assets/player_heads/Someperso.png`.
- Added `profiles/Someperso.html` using the same profile layout as other members and populated the provided fields (First Joined: `Season 12`, Seasons Played: `1`, Main Timezone: `N/A`, Primary Playstyle: `Explorer`, Playtime: `0`, Deaths: `0`, Favorite Biome: `N/A`, Mobs Killed: `N/A`).
- Filled Builds & Projects and Community Highlights sections with `N/A` entries and left Quick Tags and Recognition empty as requested.
- Included the same client scripts used by other profiles (`../assets/server-status.js` and `profile-status.js`) to keep behavior consistent.

### Testing
- Ran `rg -n "Someperso|Mobs Killed" members.html profiles/Someperso.html` to verify the new strings are present, which succeeded.
- Inspected the file diff with `git diff -- members.html profiles/Someperso.html`, which showed the intended insertions and succeeded.
- Checked the working tree with `git status --short` to confirm the new profile file and modified `members.html` are present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed50d999e8832fac1ec473065cef4d)