### PR TITLE
Update current server tournament Challonge embed

### DIFF
--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -297,7 +297,7 @@
     <section class="section">
       <h1>Current Server Tournament</h1>
       <div class="frame-wrap">
-        <iframe src="https://challonge.com/6dk8cz7n/module" width="100%" height="500" frameborder="0" scrolling="auto" allowtransparency="true"></iframe>
+        <iframe src="https://challonge.com/p5uwqt0y/module" width="100%" height="500" frameborder="0" scrolling="auto" allowtransparency="true"></iframe>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Point the "Current Server Tournament" embed to the new Challonge module so the live tournament shown on the standings page is up to date.

### Description
- Replaced the iframe `src` in `tournament-standings.html` from `https://challonge.com/6dk8cz7n/module` to `https://challonge.com/p5uwqt0y/module`.

### Testing
- Verified the update by running `rg -n "p5uwqt0y" tournament-standings.html` and inspecting the file lines with `nl -ba tournament-standings.html`, which confirmed the new URL is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0127137f8832fb22dbe67f0e1fc26)