### PR TITLE
Add Monthly Member Awards article to home and news pages

### DIFF
--- a/assets/news/mbh-winner.svg
+++ b/assets/news/mbh-winner.svg
@@ -12,5 +12,5 @@
     <circle cx="170" cy="120" r="140"/>
     <circle cx="1170" cy="470" r="200"/>
   </g>
-  <text x="80" y="280" fill="#eef3ff" font-size="64" font-family="Inter,Segoe UI,sans-serif" font-weight="700">MBH Winner Showcase</text>
+  <text x="80" y="280" fill="#eef3ff" font-size="64" font-family="Inter,Segoe UI,sans-serif" font-weight="700">MMA Winner Showcase</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -917,6 +917,15 @@
         <div class="news-grid fade-in slide-up">
           <article class="card news-card hover-lift fade-in slide-up">
             <span class="tag">Announcement</span>
+            <h3>Monthly Member Awards</h3>
+            <p>
+              Announcement of the winner of the first S12 Member Base Highlight, Gameplay Award, and Community Awards...
+            </p>
+            <a href="news.html#news-monthly-member-awards-2026-05-04" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+          </article>
+
+          <article class="card news-card hover-lift fade-in slide-up">
+            <span class="tag">Announcement</span>
             <h3>New Legacy Members</h3>
             <p>
               For consistently playing on the server since the beginning of Season 11, making many contributions during Season 11 and now in Season 12...
@@ -932,16 +941,6 @@
             </p>
             <a href="news.html#news-season-12-has-begun-2026-04-14" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>
-
-          <article class="card news-card hover-lift fade-in slide-up">
-            <span class="tag">Announcement</span>
-            <h3>Update Still In Progress</h3>
-            <p>
-              "Alpha builds for Paper 26.1.1 are now available. There is still no ETA for a stable build." - Paper Developers...
-            </p>
-            <a href="news.html#news-update-still-in-progress-2026-04-06" style="color: var(--cyan); font-weight: 700;">Read more →</a>
-          </article>
-
 
         </div>
       </div>

--- a/news.html
+++ b/news.html
@@ -223,7 +223,7 @@
       gap: 8px;
     }
 
-    .results {
+    .article-content ul.results {
       margin: 12px 0 0;
       padding: 0;
       list-style: none;
@@ -231,7 +231,7 @@
       gap: 10px;
     }
 
-    .results li {
+    .article-content ul.results li {
       display: grid;
       gap: 6px;
     }

--- a/news.html
+++ b/news.html
@@ -223,6 +223,50 @@
       gap: 8px;
     }
 
+    .results {
+      margin: 12px 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 10px;
+    }
+
+    .results li {
+      display: grid;
+      gap: 6px;
+    }
+
+    .label-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      font-size: 0.95rem;
+    }
+
+    .label-row span:last-child {
+      color: var(--muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .bar {
+      position: relative;
+      height: 9px;
+      border-radius: 999px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.18);
+    }
+
+    .bar > i {
+      position: absolute;
+      inset: 0;
+      width: var(--w);
+      background: linear-gradient(90deg, var(--cyan), var(--green));
+    }
+
+    .bar.pink > i {
+      background: linear-gradient(90deg, #ff8ec1, var(--gold));
+    }
+
     .edit-note {
       margin-top: 24px;
       padding: 14px 16px;
@@ -428,6 +472,7 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
+        <a href="#news-monthly-member-awards-2026-05-04" style="color: var(--cyan); font-weight: 700;">Monthly Member Awards</a> •
         <a href="#news-new-legacy-members-2026-04-24" style="color: var(--cyan); font-weight: 700;">New Legacy Members</a> •
         <a href="#news-season-12-has-begun-2026-04-14" style="color: var(--cyan); font-weight: 700;">Season 12 has begun</a> •
         <a href="#news-update-still-in-progress-2026-04-06" style="color: var(--cyan); font-weight: 700;">Update in progress</a> •
@@ -438,6 +483,41 @@
 
     <section>
       <div class="container news-list">
+        <article class="article" id="news-monthly-member-awards-2026-05-04">
+          <header class="article-header">
+            <div class="article-meta">
+              <span class="tag">Announcement</span>
+              <time class="date" datetime="2026-05-04">May 4, 2026</time>
+            </div>
+            <h2>Monthly Member Awards</h2>
+          </header>
+          <img
+            class="article-image"
+            src="assets/news/mbh-winner.svg"
+            alt="Feature image for the Monthly Member Awards announcement"
+          />
+          <div class="article-content">
+            <p>Winner of MBH is a tie between Atlaskytan and McCreeper1318.</p>
+            <ul class="results">
+              <li><div class="label-row"><span>Atlaskytan</span><span>4</span></div><div class="bar" style="--w:100%;"><i></i></div></li>
+              <li><div class="label-row"><span>McCreeper1318</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+            </ul>
+
+            <p>Winner of Gameplay Award is Kananers.</p>
+            <ul class="results">
+              <li><div class="label-row"><span>McCreeper1318</span><span>1</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>pinapple_pete</span><span>1</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>Kananers</span><span>2</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+            </ul>
+
+            <p>Winner of the community award is McCreeper1318.</p>
+            <ul class="results">
+              <li><div class="label-row"><span>nicholattee</span><span>1</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>McCreeper1318</span><span>2</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+            </ul>
+          </div>
+        </article>
+
         <article class="article" id="news-new-legacy-members-2026-04-24">
           <header class="article-header">
             <div class="article-meta">


### PR DESCRIPTION
### Motivation
- Add a new announcement for the Monthly Member Awards to the site so visitors can see winners and vote summaries for the first S12 Member Base Highlight, Gameplay Award, and Community Award.
- Surface the new article prominently by placing a summary card on the home page news grid as the left-most item and keep the news archive linked.

### Description
- Added a new news card to `index.html` titled `Monthly Member Awards` with the provided summary and a link to `news.html#news-monthly-member-awards-2026-05-04` so it appears as the left-most / latest item in the home news grid.
- Removed the previous right-most home news card so the visible card set matches the requested layout.
- Added a full article to `news.html` with the title `Monthly Member Awards`, the specified winners, and vote-summary blocks for MBH, Gameplay Award, and Community Award that visually match the existing `vote-history.html` style (label rows and progress bars).
- Introduced scoped vote-summary CSS in `news.html` (`.results`, `.label-row`, `.bar`) and added a jump link for the new article in the news archive section.

### Testing
- No automated tests were configured or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d0699b18832fa05910c29a4062fc)