### PR TITLE
Add May 6 vote result to vote-history page

### DIFF
--- a/vote-history.html
+++ b/vote-history.html
@@ -366,11 +366,11 @@
     <section class="stat-grid" aria-label="Vote history summary">
       <article class="stat">
         <span class="kicker">Total Polls</span>
-        <strong>14</strong>
+        <strong>15</strong>
       </article>
       <article class="stat">
         <span class="kicker">Date Range</span>
-        <strong>Dec 2025 → Apr 2026</strong>
+        <strong>Dec 2025 → May 2026</strong>
       </article>
       <article class="stat">
         <span class="kicker">Most Votes in a Poll</span>
@@ -383,6 +383,15 @@
     </section>
 
     <section class="timeline" aria-label="Voting timeline">
+      <article class="vote">
+        <span class="date">5/6/26</span>
+        <h2>Switch to paper 26.1.2 or wait for 26.2</h2>
+        <ul class="results">
+          <li><div class="label-row"><span>Switch to Paper 26.1.2</span><span>0</span></div><div class="bar" style="--w:0%;"><i></i></div></li>
+          <li><div class="label-row"><span>Wait for 26.2.0</span><span>5</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+        </ul>
+      </article>
+
       <article class="vote">
         <span class="date">4/15/26</span>
         <h2>Expand border by 500 blocks?</h2>


### PR DESCRIPTION
### Motivation
- Record the community poll about switching to Paper vs waiting for the next Paper release so the timeline is complete.
- Keep the on-page summary stats consistent with the added poll by updating the totals and date range.

### Description
- Updated `vote-history.html` to add a new top-of-timeline vote entry dated `5/6/26` titled "Switch to paper 26.1.2 or wait for 26.2" with results `Switch to Paper 26.1.2: 0` and `Wait for 26.2.0: 5`.
- Incremented the `Total Polls` from `14` to `15` in `vote-history.html`.
- Updated the `Date Range` summary in `vote-history.html` from `Dec 2025 → Apr 2026` to `Dec 2025 → May 2026`.

### Testing
- No automated tests were run because this is a content-only HTML update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb47d88e88832fb3e3150672ff237c)