### PR TITLE
Optimize fullscreen background layer performance across shared pages

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -29,8 +29,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/about-us.html
+++ b/about-us.html
@@ -28,8 +28,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/faq.html
+++ b/faq.html
@@ -31,8 +31,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/index.html
+++ b/index.html
@@ -35,8 +35,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(3px) brightness(0.5) saturate(1.08);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/members.html
+++ b/members.html
@@ -32,8 +32,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/news.html
+++ b/news.html
@@ -34,8 +34,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -32,8 +32,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/vote-history.html
+++ b/vote-history.html
@@ -32,8 +32,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 

--- a/vote-links.html
+++ b/vote-links.html
@@ -31,8 +31,7 @@
       inset: -18px;
       z-index: -2;
       pointer-events: none;
-      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat fixed;
-      filter: blur(7px) brightness(0.48) saturate(1.1);
+      background: url("assets/branding/MCV_SPR26Drop_TT_DotNet_Wallpaper_2560x1440.svg") center / cover no-repeat;
       transform: scale(1.03);
     }
 
@@ -93,7 +92,6 @@
       inset: 10% 2% 8%;
       background: radial-gradient(circle, rgba(95,255,156,0.09), transparent 65%);
       z-index: -1;
-      filter: blur(8px);
     }
 
     .vote-card {


### PR DESCRIPTION
### Motivation
- Reduce GPU-heavy real-time compositing by removing expensive CSS filter chains and fixed background attachment from shared fullscreen background layers to improve scrolling and rendering on mobile and low-end GPUs.
- Preserve visual contrast and readability by keeping the lightweight overlay gradient already applied via `body::after` rather than relying on live background filters.

### Description
- Updated `body::before` in `index.html`, `news.html`, `faq.html`, `members.html`, `vote-links.html`, `vote-history.html`, `about-us.html`, `about-season-12.html`, and `tournament-standings.html` to replace `... no-repeat fixed` with `... no-repeat` and removed `filter: blur(...) brightness(...) saturate(...)` from the fullscreen background layer. 
- Kept existing `body::after` overlay gradients intact to maintain darkening and contrast for text and UI. 
- Removed an additional local `filter: blur(8px)` on `.vote-galaxy::before` to avoid extra GPU work. 
- Did not add pre-blurred raster/WebP assets because image tooling installation was blocked in this environment, so the change is CSS-only.

### Testing
- Ran a targeted search to confirm updates with `rg -n "body::before|MCV_SPR26Drop|no-repeat fixed|filter:\s*blur\("` against the modified templates and the search showed no remaining `no-repeat fixed` or `filter: blur(...)` on the fullscreen layer (success). 
- Verified working tree reflects the HTML/CSS updates and files are modified as expected (success). 
- Attempts to install image tooling for SVG→raster generation using `npm install sharp @resvg/resvg-js` failed with a `403 Forbidden` from the registry (failure). 
- Attempts to install `pillow`/`cairosvg` with `pip install --user pillow cairosvg` failed due to registry/proxy restrictions (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9ac7ccf8832f9828490b5eb104b1)