### PR TITLE
Add June 2026 award winners news article

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,6 +919,15 @@
         <div class="news-grid fade-in slide-up">
           <article class="card news-card hover-lift fade-in slide-up">
             <span class="tag">Announcement</span>
+            <h3>June 2026 Award Winners Announced</h3>
+            <p>
+              Pinnacle SMP is proud to announce the June 2026 award winners!
+            </p>
+            <a href="news.html#news-june-2026-award-winners-announced-2026-06-02" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+          </article>
+
+          <article class="card news-card hover-lift fade-in slide-up">
+            <span class="tag">Announcement</span>
             <h3>Gallery Update</h3>
             <p>
               The Pinnacle SMP Gallery is getting a cleaner layout for Season 12!...
@@ -933,15 +942,6 @@
               The Pinnacle SMP community recently held a vote on whether the server should switch to Paper 26.1.2 now or wait for the upcoming 26.2 release...
             </p>
             <a href="news.html#news-community-votes-to-wait-for-26-2-2026-05-06" style="color: var(--cyan); font-weight: 700;">Read more →</a>
-          </article>
-
-          <article class="card news-card hover-lift fade-in slide-up">
-            <span class="tag">Announcement</span>
-            <h3>Monthly Member Awards</h3>
-            <p>
-              Announcement of the winner of the first S12 Member Base Highlight, Gameplay Award, and Community Awards...
-            </p>
-            <a href="news.html#news-monthly-member-awards-2026-05-04" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -923,7 +923,7 @@
             <p>
               Pinnacle SMP is proud to announce the June 2026 award winners!
             </p>
-            <a href="news.html#news-june-2026-award-winners-announced-2026-06-02" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+            <a href="news.html#news-june-2026-award-winners-announced-2026-06-01" style="color: var(--cyan); font-weight: 700;">Read more →</a>
           </article>
 
           <article class="card news-card hover-lift fade-in slide-up">

--- a/members.html
+++ b/members.html
@@ -478,15 +478,15 @@
         <h2>Monthly Member Awards</h2>
         <div class="award-highlight">
           <h3>Member Base Highlight</h3>
-          <p>Atlaskytan and McCreeper1318</p>
+          <p>nicholattee</p>
         </div>
         <div class="award-highlight" style="margin-top: 10px;">
           <h3>Gameplay Award</h3>
-          <p>Kananers</p>
+          <p>mermaidxellie</p>
         </div>
         <div class="award-highlight" style="margin-top: 10px;">
           <h3>Community Award</h3>
-          <p>McCreeper1318</p>
+          <p>Atlaskytan and mermaidxellie</p>
         </div>
       </section>
     </section>

--- a/news.html
+++ b/news.html
@@ -471,7 +471,7 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
-        <a href="#news-june-2026-award-winners-announced-2026-06-02" style="color: var(--cyan); font-weight: 700;">June 2026 Award Winners Announced</a> •
+        <a href="#news-june-2026-award-winners-announced-2026-06-01" style="color: var(--cyan); font-weight: 700;">June 2026 Award Winners Announced</a> •
         <a href="#gallery-update-may-26" style="color: var(--cyan); font-weight: 700;">Gallery Update</a> •
         <a href="#news-community-votes-to-wait-for-26-2-2026-05-06" style="color: var(--cyan); font-weight: 700;">Community Votes to Wait for 26.2</a> •
         <a href="#news-monthly-member-awards-2026-05-04" style="color: var(--cyan); font-weight: 700;">Monthly Member Awards</a> •
@@ -486,11 +486,11 @@
     <section>
       <div class="container news-list">
 
-        <article class="article" id="news-june-2026-award-winners-announced-2026-06-02">
+        <article class="article" id="news-june-2026-award-winners-announced-2026-06-01">
           <header class="article-header">
             <div class="article-meta">
               <span class="tag">Announcement</span>
-              <time class="date" datetime="2026-06-02">June 2, 2026</time>
+              <time class="date" datetime="2026-06-01">June 1, 2026</time>
             </div>
             <h2>June 2026 Award Winners Announced</h2>
           </header>
@@ -508,7 +508,7 @@
               <li><div class="label-row"><span>mermaidxellie</span><span>3</span></div><div class="bar" style="--w:75%;"><i></i></div></li>
               <li><div class="label-row"><span>StirfrySurprise</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
               <li><div class="label-row"><span>nicholattee</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
-              <li><div class="label-row"><span>Dissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>Diissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
             </ul>
 
             <p>Gameplay Award Results:</p>
@@ -517,8 +517,8 @@
               <li><div class="label-row"><span>McCreeper1318</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
               <li><div class="label-row"><span>mermaidxellie</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
               <li><div class="label-row"><span>StirfrySurprise</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
-              <li><div class="label-row"><span>ncholattee</span><span>2</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
-              <li><div class="label-row"><span>Dissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>nicholattee</span><span>2</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>Diissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
               <li><div class="label-row"><span>Someperso</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
             </ul>
 

--- a/news.html
+++ b/news.html
@@ -471,6 +471,7 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
+        <a href="#news-june-2026-award-winners-announced-2026-06-02" style="color: var(--cyan); font-weight: 700;">June 2026 Award Winners Announced</a> •
         <a href="#gallery-update-may-26" style="color: var(--cyan); font-weight: 700;">Gallery Update</a> •
         <a href="#news-community-votes-to-wait-for-26-2-2026-05-06" style="color: var(--cyan); font-weight: 700;">Community Votes to Wait for 26.2</a> •
         <a href="#news-monthly-member-awards-2026-05-04" style="color: var(--cyan); font-weight: 700;">Monthly Member Awards</a> •
@@ -485,7 +486,53 @@
     <section>
       <div class="container news-list">
 
-                <article class="article" id="gallery-update-may-26">
+        <article class="article" id="news-june-2026-award-winners-announced-2026-06-02">
+          <header class="article-header">
+            <div class="article-meta">
+              <span class="tag">Announcement</span>
+              <time class="date" datetime="2026-06-02">June 2, 2026</time>
+            </div>
+            <h2>June 2026 Award Winners Announced</h2>
+          </header>
+          <div class="article-content">
+            <p>Pinnacle SMP is proud to announce the June 2026 award winners! This month, nicholattee earned the Member Base Highlight award, recognizing an outstanding build and base design within the community.</p>
+            <p>The Gameplay Award goes to mermaidxellie for standout activity and contributions through gameplay during the month of June.</p>
+            <p>For the Community Award, we have a tie! Congratulations to both Atlaskytan and mermaidxellie for their positive impact and involvement in the Pinnacle SMP community.</p>
+            <p>Congratulations to all of our June winners, and thank you to everyone who continues to help make Pinnacle SMP a great place to play!</p>
+
+            <p>Member Base Highlight Results:</p>
+            <ul class="results">
+              <li><div class="label-row"><span>Atlaskytan</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>Beslife</span><span>2</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>McCreeper1318</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>mermaidxellie</span><span>3</span></div><div class="bar" style="--w:75%;"><i></i></div></li>
+              <li><div class="label-row"><span>StirfrySurprise</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>nicholattee</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+              <li><div class="label-row"><span>Dissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+            </ul>
+
+            <p>Gameplay Award Results:</p>
+            <ul class="results">
+              <li><div class="label-row"><span>Atlaskytan</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>McCreeper1318</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>mermaidxellie</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+              <li><div class="label-row"><span>StirfrySurprise</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>ncholattee</span><span>2</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+              <li><div class="label-row"><span>Dissonance</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>Someperso</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+            </ul>
+
+            <p>Community Award Results:</p>
+            <ul class="results">
+              <li><div class="label-row"><span>Atlaskytan</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+              <li><div class="label-row"><span>mermaidxellie</span><span>4</span></div><div class="bar pink" style="--w:100%;"><i></i></div></li>
+              <li><div class="label-row"><span>nicholattee</span><span>1</span></div><div class="bar" style="--w:25%;"><i></i></div></li>
+              <li><div class="label-row"><span>McCreeper1318</span><span>2</span></div><div class="bar" style="--w:50%;"><i></i></div></li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="article" id="gallery-update-may-26">
           <header class="article-header">
             <div class="article-meta">
               <span class="tag">Announcement</span>


### PR DESCRIPTION
### Motivation
- Publish the June 2026 monthly awards announcement in the news archive and promote it on the homepage using the existing awards article structure and visual result bars.
- Keep the new article consistent with the May 4, 2026 awards format so readers see the same layout and vote-result styling.

### Description
- Added a new article block to `news.html` with id `news-june-2026-award-winners-announced-2026-06-02` and date `2026-06-02` containing the requested announcement paragraphs and award summaries.
- Included Member Base Highlight, Gameplay Award, and Community Award result lists using the same `.results`/`.bar` progress-bar markup as the existing awards article.
- Inserted a jump link for the new article in the news archive header in `news.html` and added a news card with the requested excerpt to the homepage `index.html` linking to the new article.
- Used the provided player names and vote counts verbatim in the results lists.

### Testing
- Parsed `index.html` and `news.html` with Python's `html.parser` and verified there are no duplicate `id` attributes and that the new article anchor is present and linked from the homepage.
- Verified the `time` `datetime` value, the four required announcement paragraphs appear verbatim in `news.html`, and the expected vote entries exist in the article.
- Ran `git diff --check` to ensure no whitespace or diff issues and confirmed the working tree was updated as expected.
- Rendering screenshots were not captured because a browser executable was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e2d256354832f9ec46f7e64b39c27)