### PR TITLE
Update Pinnacle SMP site logo references

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -210,7 +210,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>

--- a/about-us.html
+++ b/about-us.html
@@ -233,7 +233,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
@@ -252,7 +252,7 @@
 
   <main class="container">
     <section class="panel">
-      <center><img class="hero-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP logo" /></center>
+      <center><img class="hero-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP logo" /></center>
       <h1>Who we are…</h1>
       <p>
 Pinnacle SMP is a Vanilla+ Minecraft server that got its start in 2012 when McCreeper1318 started hosting a public Minecraft server. Once a few people joined it was quickly switched to a whitelisted server because of griefing, but not before he met Piff and Jeff.

--- a/faq.html
+++ b/faq.html
@@ -258,7 +258,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>

--- a/gallery-season-11.html
+++ b/gallery-season-11.html
@@ -15,7 +15,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
 .panel{background:var(--panel);border:1px solid var(--line);border-radius:24px;padding:28px;box-shadow:var(--shadow)}
 @media(max-width:860px){.nav-wrap{min-height:unset;padding:12px 0;flex-wrap:wrap}.menu-toggle{display:inline-flex}#mobile-nav{display:none;width:100%}.site-header.nav-open #mobile-nav{display:block}#mobile-nav .nav-buttons{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;margin-top:10px}.nav-buttons .btn{width:100%;min-height:40px;padding:0 13px;font-size:.9rem}}
 </style></head><body>
-<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
+<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
         <div class="cta-row nav-buttons" role="list">
           <a class="btn btn-secondary hover-lift" href="index.html#home">Home</a>
           <a class="btn btn-secondary hover-lift" href="index.html#news">Server News</a>

--- a/gallery-season-12.html
+++ b/gallery-season-12.html
@@ -18,7 +18,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
 .gallery-breadcrumbs a:hover{text-decoration:underline}
 @media(max-width:860px){.nav-wrap{min-height:unset;padding:12px 0;flex-wrap:wrap}.menu-toggle{display:inline-flex}#mobile-nav{display:none;width:100%}.site-header.nav-open #mobile-nav{display:block}#mobile-nav .nav-buttons{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;margin-top:10px}.nav-buttons .btn{width:100%;min-height:40px;padding:0 13px;font-size:.9rem}}
 </style></head><body>
-<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
+<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
         <div class="cta-row nav-buttons" role="list">
           <a class="btn btn-secondary hover-lift" href="index.html#home">Home</a>
           <a class="btn btn-secondary hover-lift" href="index.html#news">Server News</a>

--- a/gallery.html
+++ b/gallery.html
@@ -15,7 +15,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
 .panel{background:var(--panel);border:1px solid var(--line);border-radius:24px;padding:28px;box-shadow:var(--shadow)}
 @media(max-width:860px){.nav-wrap{min-height:unset;padding:12px 0;flex-wrap:wrap}.menu-toggle{display:inline-flex}#mobile-nav{display:none;width:100%}.site-header.nav-open #mobile-nav{display:block}#mobile-nav .nav-buttons{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;margin-top:10px}.nav-buttons .btn{width:100%;min-height:40px;padding:0 13px;font-size:.9rem}}
 </style></head><body>
-<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
+<header class="site-header"><div class="nav-wrap"><a href="index.html#home" class="brand"><img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" /><span>Pinnacle SMP</span></a><button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button><nav id="mobile-nav" aria-label="Main navigation">
         <div class="cta-row nav-buttons" role="list">
           <a class="btn btn-secondary hover-lift" href="index.html#home">Home</a>
           <a class="btn btn-secondary hover-lift" href="index.html#news">Server News</a>

--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
     <div class="container nav-wrap">
       <div class="brand-group">
         <a href="#home" class="brand">
-          <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
           <span>Pinnacle SMP</span>
         </a>
         <a id="server-status-badge" class="brand-status" href="members.html" aria-live="polite">
@@ -1086,7 +1086,7 @@
     <div class="container footer-grid">
       <div class="footer-brand">
         <div class="brand" style="margin-bottom: 12px;">
-          <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
           <span>Pinnacle SMP</span>
         </div>
         <p>

--- a/members.html
+++ b/members.html
@@ -413,7 +413,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>

--- a/news.html
+++ b/news.html
@@ -446,7 +446,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -276,7 +276,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>

--- a/vote-history.html
+++ b/vote-history.html
@@ -340,7 +340,7 @@
   <header class="site-header">
     <div class="nav-wrap">
       <a href="index.html#home" class="brand">
-        <img class="brand-logo" src="assets/branding/PinnacleSeason12Logo.svg" alt="Pinnacle SMP Season 12 logo" />
+        <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
         <span>Pinnacle SMP</span>
       </a>
       <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>


### PR DESCRIPTION
### Motivation
- Bring all site logo images up to date by replacing the legacy local SVG with the new Cloudinary PNG while preserving layout and sizing.
- Only alter site branding references and leave gallery photos, player heads, awards, and unrelated assets unchanged.

### Description
- Replaced `assets/branding/PinnacleSeason12Logo.svg` with `https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png` across the site.
- Files updated: `index.html`, `about-us.html`, `about-season-12.html`, `faq.html`, `gallery.html`, `gallery-season-11.html`, `gallery-season-12.html`, `members.html`, `news.html`, `tournament-standings.html`, and `vote-history.html`.
- Updated header/navigation logos, the home-page footer logo, and the About Us hero logo while preserving existing `alt` text and CSS sizing rules like `.brand-logo` and `.hero-logo` (`object-fit: contain`, width/height rules remain unchanged).
- Confirmed there were no favicon/apple-touch declarations, no reusable logo component to update, and no CSS `background-image` logo usages; unrelated images were not changed.

### Testing
- HTML parser audit validated `13` site logo image references across `11` HTML files now point to the new Cloudinary URL (passed).
- HTML parser audit validated `50` local image/icon references across HTML files and found no broken local image paths (passed).
- Repository search with `rg` confirmed no remaining `assets/branding/PinnacleSeason12Logo.svg` references and completed a hidden-file-inclusive audit for logo/icon/background tokens (passed).
- Served the site locally with `python3 -m http.server` and fetched `index.html` with `curl` to verify the updated page served (passed).
- Attempt to fetch the remote Cloudinary PNG with `curl` failed with HTTP 403 due to the environment proxy, so remote asset availability and automated visual screenshots could not be verified from this environment (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f361bb58c832f948878b6d14f8de9)