### PR TITLE
Add footer version text

### DIFF
--- a/about-season-12.html
+++ b/about-season-12.html
@@ -348,7 +348,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script>

--- a/about-us.html
+++ b/about-us.html
@@ -322,7 +322,7 @@ Currently Pinnacle is on its 12th season and has no current plans on starting se
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 

--- a/faq.html
+++ b/faq.html
@@ -429,7 +429,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 

--- a/gallery-season-11.html
+++ b/gallery-season-11.html
@@ -92,7 +92,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 <script>(()=>{const h=document.querySelector('.site-header');const t=document.querySelector('.menu-toggle');const n=document.getElementById('mobile-nav');if(h&&t&&n){const c=()=>{h.classList.remove('nav-open');t.setAttribute('aria-expanded','false')};t.addEventListener('click',()=>{const o=h.classList.toggle('nav-open');t.setAttribute('aria-expanded',String(o))});n.querySelectorAll('a').forEach((l)=>l.addEventListener('click',c));window.addEventListener('resize',()=>{if(window.innerWidth>860)c()});}

--- a/gallery-season-12.html
+++ b/gallery-season-12.html
@@ -95,7 +95,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 <script>(()=>{const h=document.querySelector('.site-header');const t=document.querySelector('.menu-toggle');const n=document.getElementById('mobile-nav');if(h&&t&&n){const c=()=>{h.classList.remove('nav-open');t.setAttribute('aria-expanded','false')};t.addEventListener('click',()=>{const o=h.classList.toggle('nav-open');t.setAttribute('aria-expanded',String(o))});n.querySelectorAll('a').forEach((l)=>l.addEventListener('click',c));window.addEventListener('resize',()=>{if(window.innerWidth>860)c()});}})();</script>

--- a/gallery.html
+++ b/gallery.html
@@ -92,7 +92,7 @@ body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;backgr
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 <script>(()=>{const h=document.querySelector('.site-header');const t=document.querySelector('.menu-toggle');const n=document.getElementById('mobile-nav');if(!h||!t||!n)return;const c=()=>{h.classList.remove('nav-open');t.setAttribute('aria-expanded','false')};t.addEventListener('click',()=>{const o=h.classList.toggle('nav-open');t.setAttribute('aria-expanded',String(o))});n.querySelectorAll('a').forEach((l)=>l.addEventListener('click',c));window.addEventListener('resize',()=>{if(window.innerWidth>860)c()});})();</script>

--- a/index.html
+++ b/index.html
@@ -1089,7 +1089,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="assets/server-status.js"></script>

--- a/members.html
+++ b/members.html
@@ -545,7 +545,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="assets/server-status.js"></script>

--- a/news.html
+++ b/news.html
@@ -748,7 +748,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 

--- a/profiles/Aryamii.html
+++ b/profiles/Aryamii.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Atlaskytan.html
+++ b/profiles/Atlaskytan.html
@@ -154,7 +154,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/BACONcuzBACON.html
+++ b/profiles/BACONcuzBACON.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/BadFiction.html
+++ b/profiles/BadFiction.html
@@ -157,7 +157,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/BeansUniverse.html
+++ b/profiles/BeansUniverse.html
@@ -155,7 +155,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Beslife.html
+++ b/profiles/Beslife.html
@@ -153,7 +153,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/BraneFX.html
+++ b/profiles/BraneFX.html
@@ -153,7 +153,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Diissonance.html
+++ b/profiles/Diissonance.html
@@ -151,7 +151,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/GodlyCris.html
+++ b/profiles/GodlyCris.html
@@ -153,7 +153,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/IronArmored.html
+++ b/profiles/IronArmored.html
@@ -156,7 +156,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Jeff.html
+++ b/profiles/Jeff.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/JohnnyKilroy.html
+++ b/profiles/JohnnyKilroy.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Kananers.html
+++ b/profiles/Kananers.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Kelly_E.html
+++ b/profiles/Kelly_E.html
@@ -154,7 +154,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/McCreeper1318.html
+++ b/profiles/McCreeper1318.html
@@ -158,7 +158,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/MoeBe10.html
+++ b/profiles/MoeBe10.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/NateOnGuitar.html
+++ b/profiles/NateOnGuitar.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/NoctuLocktoo.html
+++ b/profiles/NoctuLocktoo.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Piff.html
+++ b/profiles/Piff.html
@@ -154,7 +154,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Poplare.html
+++ b/profiles/Poplare.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Ratatuii20.html
+++ b/profiles/Ratatuii20.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/Someperso.html
+++ b/profiles/Someperso.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/StirfrySurprise.html
+++ b/profiles/StirfrySurprise.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/SweetBunny16.html
+++ b/profiles/SweetBunny16.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/blade326.html
+++ b/profiles/blade326.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/kylethecaver.html
+++ b/profiles/kylethecaver.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/mermaidxellie.html
+++ b/profiles/mermaidxellie.html
@@ -153,7 +153,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/misfiired.html
+++ b/profiles/misfiired.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/nicholattee.html
+++ b/profiles/nicholattee.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/notnownotnever.html
+++ b/profiles/notnownotnever.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/pinapple_pete.html
+++ b/profiles/pinapple_pete.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/profiles/t0w0fu.html
+++ b/profiles/t0w0fu.html
@@ -152,7 +152,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="../assets/server-status.js"></script>

--- a/rules.html
+++ b/rules.html
@@ -1230,7 +1230,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="assets/server-status.js"></script>

--- a/tournament-standings.html
+++ b/tournament-standings.html
@@ -444,7 +444,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 

--- a/vote-history.html
+++ b/vote-history.html
@@ -587,7 +587,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
 

--- a/vote-links.html
+++ b/vote-links.html
@@ -284,7 +284,7 @@
     </div>
 
     <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved.
+      © 2026 Pinnacle SMP. All rights reserved. v. 106.6071440
     </div>
   </footer>
   <script src="assets/server-status.js"></script>


### PR DESCRIPTION
### Motivation
- Ensure every site page displays the same footer version identifier by appending `v. 106.6071440` to the existing copyright text.

### Description
- Updated the footer line in 45 HTML files to append `v. 106.6071440` after the copyright sentence.
- The replacement changes the text from `© 2026 Pinnacle SMP. All rights reserved.` to `© 2026 Pinnacle SMP. All rights reserved. v. 106.6071440` on root pages, gallery pages, news/rules/members pages and profile pages.
- Only the footer text was modified; no other markup, scripts, or styles were altered.
- All HTML files were scanned and updated consistently so every page shows the same version string.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or diff issues and it passed.
- Verified that the count of `v. 106.6071440` occurrences in HTML files matches the total number of HTML files using `rg -n "v\. 106\.6071440" -g '*.html' | wc -l` vs `rg --files -g '*.html' | wc -l`, and the counts matched (45/45).
- Confirmed the repository diff shows the expected 45 file updates with 45 insertions and 45 deletions and no unrelated changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25bb240b58832fb477aa42244b4e39)