### PR TITLE
Fix membership notice banner styling

### DIFF
--- a/assets/light-theme.css
+++ b/assets/light-theme.css
@@ -102,16 +102,21 @@
   position: sticky;
   top: 82px;
   z-index: 45;
-  background: linear-gradient(135deg, rgba(249, 226, 175, 0.96), rgba(250, 179, 135, 0.96));
-  border-bottom: 1px solid rgba(250, 179, 135, 0.62);
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  background: linear-gradient(135deg, rgba(249, 226, 175, 0.98), rgba(250, 179, 135, 0.98));
+  border-bottom: 1px solid rgba(250, 179, 135, 0.7);
   color: #3b2600;
   box-shadow: 0 10px 24px rgba(17, 17, 27, 0.18);
 }
 
 .site-warning-banner__inner {
-  width: min(calc(100% - 32px), 1240px);
+  width: min(100%, 1240px);
   margin: 0 auto;
-  padding: 12px 0;
+  padding: 0;
+  color: inherit;
+  font-size: 1rem;
   font-weight: 800;
   line-height: 1.45;
   text-align: center;
@@ -120,10 +125,10 @@
 @media (max-width: 760px) {
   .site-warning-banner {
     top: 70px;
+    padding: 9px 10px;
   }
 
   .site-warning-banner__inner {
-    width: min(calc(100% - 20px), 1240px);
     font-size: 0.92rem;
   }
 }


### PR DESCRIPTION
### Motivation
- The membership notice banner was not rendering with the intended full-width, padded bar appearance and could appear misaligned with the site chrome.  
- The goal is to make the notice visually consistent with the header/footer layout and keep the message centered and constrained at larger viewports.  
- The banner must remain sticky with an appropriate offset on small screens so it doesn’t overlap the header.

### Description
- Adjusted `.site-warning-banner` in `assets/light-theme.css` to use `display: block`, `width: 100%`, explicit `padding`, a slightly stronger background alpha, and a clearer border color so the banner renders as a full-width, distinct bar.  
- Updated `.site-warning-banner__inner` to `width: min(100%, 1240px)`, remove inner padding, `color: inherit`, and set `font-size: 1rem` so the copy is centered, constrained, and inherits the banner text color.  
- Preserved the sticky offset and added compact padding under `@media (max-width: 760px)` to keep spacing correct on mobile.

### Testing
- Ran `git diff --check` which completed successfully.  
- Attempted a headless screenshot test using Playwright (`node -e "const { chromium } = require('playwright'...)"`) to verify visual output, but the test could not run because Playwright is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39046ddfe8832fac32ca8b49fdb5f7)