### PR TITLE
Add 'Griefing Incident and Rollback' news story (June 24, 2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,6 +923,15 @@
 
         <div class="news-grid fade-in slide-up">
           <article class="card news-card hover-lift fade-in slide-up">
+            <span class="tag">News</span>
+            <h3>Griefing Incident and Rollback</h3>
+            <p>
+              Pinnacle SMP has been restored from the June 20 save after a griefing incident, and new FG tools are now in place to help staff investigate and undo future damage.
+            </p>
+            <a href="news.html#news-griefing-incident-and-rollback-2026-06-24" style="color: var(--cyan); font-weight: 700;">Read more →</a>
+          </article>
+
+          <article class="card news-card hover-lift fade-in slide-up">
             <span class="tag">Update</span>
             <h3>We Have Updated to Paper 26.2!</h3>
             <p>

--- a/news.html
+++ b/news.html
@@ -482,6 +482,7 @@
         <h1>Pinnacle SMP Server News</h1>
       <div class="edit-note" style="margin-top: 18px;">
         <strong>Jump to article:</strong>
+        <a href="#news-griefing-incident-and-rollback-2026-06-24" style="color: var(--cyan); font-weight: 700;">Griefing Incident and Rollback</a> •
         <a href="#news-paper-26-2-update-2026-06-22" style="color: var(--cyan); font-weight: 700;">We Have Updated to Paper 26.2!</a> •
         <a href="#news-june-2026-award-winners-announced-2026-06-01" style="color: var(--cyan); font-weight: 700;">June 2026 Award Winners Announced</a> •
         <a href="#gallery-update-may-26" style="color: var(--cyan); font-weight: 700;">Gallery Update</a> •
@@ -497,6 +498,35 @@
 
     <section>
       <div class="container news-list">
+
+        <article class="article" id="news-griefing-incident-and-rollback-2026-06-24">
+          <header class="article-header">
+            <div class="article-meta">
+              <span class="tag">News</span>
+              <time class="date" datetime="2026-06-24">June 24, 2026</time>
+            </div>
+            <h2>Griefing Incident and Rollback</h2>
+          </header>
+          <div class="article-content">
+            <p>Recently, Pinnacle SMP experienced a serious griefing incident that affected both <strong>spawn</strong> and several player bases. After reviewing the damage, it became clear that the best way to protect the server and restore everyone’s progress was to roll the world back to a previous clean save.</p>
+            <p>The server has now been restored using the <strong>June 20 save</strong>. While this means some recent progress may have been lost, it allowed us to recover spawn, damaged builds, and affected bases without leaving behind broken or griefed areas.</p>
+            <p>To help prevent this kind of issue from causing as much damage in the future, we have also created a custom server plugin called <strong>FG</strong>. This plugin is designed specifically for Pinnacle SMP and gives staff better tools to track, investigate, and undo griefing.</p>
+            <p>Some of the FG plugin features include:</p>
+            <ul>
+              <li>Logging block placements and block breaks</li>
+              <li>Tracking who placed or destroyed blocks</li>
+              <li>Keeping block logs for the past <strong>30 days</strong></li>
+              <li>Searching logs within a selected radius</li>
+              <li>Rolling back changes in a radius to a specific time</li>
+              <li>Logging damage caused by explosions</li>
+              <li>Tracking fire spread damage</li>
+              <li>Logging lava and water flow changes</li>
+              <li>Tracking block movement caused by pistons</li>
+            </ul>
+            <p>With this plugin, staff will be able to inspect damaged areas more easily and, when needed, revert griefing without having to roll back the entire server.</p>
+            <p>Thank you to everyone for your patience while we worked through this. Pinnacle SMP is built around trust, respect, and community, and we will continue improving the tools and protections needed to keep the server safe and enjoyable for everyone.</p>
+          </div>
+        </article>
 
         <article class="article" id="news-paper-26-2-update-2026-06-22">
           <header class="article-header">


### PR DESCRIPTION
### Motivation
- Publish an official server notice about a recent griefing incident, the rollback to the June 20 save, and the introduction of a new FG plugin to improve grief tracking and rollbacks. 
- Make the update easy to find by adding it to the news archive jump links and the homepage news grid.

### Description
- Inserted a new article into `news.html` with id `news-griefing-incident-and-rollback-2026-06-24`, tag `News`, date `June 24, 2026`, the requested title, formatted paragraphs, and a bulleted list of FG plugin features. 
- Added a jump-link entry to the archive "Jump to article" section in `news.html` that points to the new article. 
- Added a new latest-news card to the news grid in `index.html` linking to the new archive article. 
- No other files were modified.

### Testing
- Parsed `index.html` and `news.html` with Python's `HTMLParser` to validate the modified HTML and parsing completed successfully. 
- Served the site locally with `python3 -m http.server` and confirmed `curl -I http://127.0.0.1:8000/news.html` returned `200 OK`. 
- Ran `git diff --check` to detect whitespace or diff errors and it returned clean. 
- Attempted to capture a screenshot with Playwright via `npx`, but the `npx` install failed due to an npm registry `403 Forbidden`, so screenshot verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c422065a0832fbd8ebe4a3aa88b9b)