### PR TITLE
Enable live map link

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,7 +870,7 @@
             <a class="btn btn-primary hover-lift" href="#apply-here">Apply</a>
             <a class="btn btn-secondary hover-lift" href="about-us.html">About Pinnacle</a>
             <a class="btn btn-secondary hover-lift" href="about-season-12.html">About Season 12</a>
-            <a class="btn btn-secondary btn-disabled" href="http://pinnaclesmp.mcserv.fun:1041" target="_blank" rel="noopener noreferrer" aria-disabled="true" tabindex="-1">Live Map</a>
+            <a class="btn btn-secondary hover-lift" href="http://pinnaclesmp.mcserv.fun:1041" target="_blank" rel="noopener noreferrer">Live Map</a>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Restore the Live Map call-to-action on the main page so visitors can open the live world map at `pinnaclesmp.mcserv.fun:1041`.

### Description
- Updated `index.html` to replace the disabled Live Map anchor with an enabled anchor by removing the `btn-disabled` class and the `aria-disabled`/`tabindex` attributes and applying `hover-lift`, keeping the link pointed at `http://pinnaclesmp.mcserv.fun:1041`.

### Testing
- Ran an assertion script (`python3 - <<'PY' ... PY`) that verified the new anchor is present and no disabled attributes remain and it passed.
- Served the site locally with `python3 -m http.server` and verified the served page via `curl -fsS http://localhost:8000/index.html | rg -n 'Live Map|pinnaclesmp\.mcserv\.fun:1041'`, which showed the updated link.
- Executed `git diff --check` to ensure no whitespace errors were introduced and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a448ac1138c832f9afdc2023d812b17)