### PR TITLE
Add retro website redesign news article

### DIFF
--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -16,7 +16,6 @@
     const style = document.createElement('style');
     style.id = 'retro-news-update-style';
     style.textContent = `
-      .news-heading-row{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
       .new-badge{display:inline-block;margin-left:8px;padding:2px 7px;border:2px outset #fff;background:#ff0;color:#c00;font:bold 12px "Courier New",monospace;vertical-align:middle;animation:retro-news-blink .8s steps(1,end) infinite}
       @keyframes retro-news-blink{0%,49%{visibility:visible}50%,100%{visibility:hidden}}
       @media (prefers-reduced-motion:reduce){.new-badge{animation:none}}
@@ -25,7 +24,10 @@
   }
 
   function updateHome() {
-    if (!/(^|\/)index\.html$/.test(location.pathname) && location.pathname !== '/' && !/\/pr-preview\/pr-\d+\/?$/.test(location.pathname)) return false;
+    const isHome = /(^|\/)index\.html$/.test(location.pathname) || location.pathname === '/' || /\/pr-preview\/pr-\d+\/?$/.test(location.pathname);
+    if (!isHome) return true;
+    if (document.querySelector('.newest-news-item .new-badge')) return true;
+
     const heading = [...document.querySelectorAll('main.content h2')].find(el => el.textContent.trim() === 'Latest Server News');
     if (!heading) return false;
 
@@ -49,9 +51,10 @@
   }
 
   function updateArchive() {
-    if (!/(^|\/)news\.html$/.test(location.pathname)) return false;
+    if (!/(^|\/)news\.html$/.test(location.pathname)) return true;
     const archive = document.querySelector('.news-archive');
     if (!archive) return false;
+    if (archive.dataset.retroNewsReady === 'true') return true;
 
     let newest = document.getElementById(ARTICLE.id);
     if (!newest) {
@@ -63,23 +66,18 @@
     }
 
     archive.querySelectorAll('details.news-archive-item').forEach(item => { item.open = item === newest; });
+    archive.dataset.retroNewsReady = 'true';
     return true;
   }
 
-  function apply() {
-    addStyles();
-    const homeDone = updateHome();
-    const archiveDone = updateArchive();
-    return homeDone || archiveDone;
-  }
-
   function start() {
-    apply();
+    addStyles();
     let attempts = 0;
     const timer = setInterval(() => {
       attempts += 1;
-      apply();
-      if (attempts >= 40) clearInterval(timer);
+      const homeReady = updateHome();
+      const archiveReady = updateArchive();
+      if ((homeReady && archiveReady) || attempts >= 40) clearInterval(timer);
     }, 250);
   }
 

--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -7,7 +7,7 @@
     body: `<p>The Pinnacle SMP website has received a complete visual overhaul inspired by the personal websites, gaming fan pages, and community portals of the late 1990s.</p>
       <p>The new design uses classic beveled panels, bright blue title bars, compact sidebars, pixel-style details, scrolling announcements, web counters, and other familiar elements from the early days of the internet. The goal was to give Pinnacle a more distinctive and memorable home while reflecting the community-focused character of the server.</p>
       <p>Although the website now looks intentionally retro, its important modern features remain available. Visitors can still view live server information, open member profiles, browse PinnacleStats dashboards, check tournament standings, read server rules, access voting and contact links, and explore the complete Season 11 and Season 12 screenshot galleries.</p>
-      <p>The members page has also been reorganized with rank-colored sections and direct links to each player profile. Server news is now stored in a collapsible archive so older announcements remain available without making the page excessively long.</p>
+      <p>Server news is now stored in a collapsible archive so older announcements remain available without making the page excessively long.</p>
       <p>This redesign gives Pinnacle SMP a website that feels less like a generic modern template and more like a community site built specifically for the server—just with a little dial-up-era personality.</p>`
   };
 
@@ -16,7 +16,18 @@
     const style = document.createElement('style');
     style.id = 'retro-news-update-style';
     style.textContent = `
-      .new-badge{display:inline-block;margin-left:8px;padding:2px 7px;border:2px outset #fff;background:#ff0;color:#c00;font:bold 12px "Courier New",monospace;vertical-align:middle;animation:retro-news-blink .8s steps(1,end) infinite}
+      .new-badge{
+        display:inline;
+        margin-left:8px;
+        color:#c00;
+        background:none;
+        border:0;
+        padding:0;
+        font:bold 13px "Courier New",monospace;
+        letter-spacing:.04em;
+        vertical-align:baseline;
+        animation:retro-news-blink .8s steps(1,end) infinite;
+      }
       @keyframes retro-news-blink{0%,49%{visibility:visible}50%,100%{visibility:hidden}}
       @media (prefers-reduced-motion:reduce){.new-badge{animation:none}}
     `;
@@ -55,6 +66,9 @@
     const archive = document.querySelector('.news-archive');
     if (!archive) return false;
     if (archive.dataset.retroNewsReady === 'true') return true;
+
+    const intro = archive.previousElementSibling;
+    if (intro?.tagName === 'P') intro.textContent = 'Open an article to read it.';
 
     let newest = document.getElementById(ARTICLE.id);
     if (!newest) {

--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -1,0 +1,88 @@
+(() => {
+  const ARTICLE = {
+    id: 'retro-redesign',
+    date: 'AUG 04, 2026',
+    title: "Pinnacle SMP Website Gets a Retro '90s Redesign",
+    summary: "The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.",
+    body: `<p>The Pinnacle SMP website has received a complete visual overhaul inspired by the personal websites, gaming fan pages, and community portals of the late 1990s.</p>
+      <p>The new design uses classic beveled panels, bright blue title bars, compact sidebars, pixel-style details, scrolling announcements, web counters, and other familiar elements from the early days of the internet. The goal was to give Pinnacle a more distinctive and memorable home while reflecting the community-focused character of the server.</p>
+      <p>Although the website now looks intentionally retro, its important modern features remain available. Visitors can still view live server information, open member profiles, browse PinnacleStats dashboards, check tournament standings, read server rules, access voting and contact links, and explore the complete Season 11 and Season 12 screenshot galleries.</p>
+      <p>The members page has also been reorganized with rank-colored sections and direct links to each player profile. Server news is now stored in a collapsible archive so older announcements remain available without making the page excessively long.</p>
+      <p>This redesign gives Pinnacle SMP a website that feels less like a generic modern template and more like a community site built specifically for the server—just with a little dial-up-era personality.</p>`
+  };
+
+  function addStyles() {
+    if (document.getElementById('retro-news-update-style')) return;
+    const style = document.createElement('style');
+    style.id = 'retro-news-update-style';
+    style.textContent = `
+      .news-heading-row{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
+      .new-badge{display:inline-block;margin-left:8px;padding:2px 7px;border:2px outset #fff;background:#ff0;color:#c00;font:bold 12px "Courier New",monospace;vertical-align:middle;animation:retro-news-blink .8s steps(1,end) infinite}
+      @keyframes retro-news-blink{0%,49%{visibility:visible}50%,100%{visibility:hidden}}
+      @media (prefers-reduced-motion:reduce){.new-badge{animation:none}}
+    `;
+    document.head.appendChild(style);
+  }
+
+  function updateHome() {
+    if (!/(^|\/)index\.html$/.test(location.pathname) && location.pathname !== '/' && !/\/pr-preview\/pr-\d+\/?$/.test(location.pathname)) return false;
+    const heading = [...document.querySelectorAll('main.content h2')].find(el => el.textContent.trim() === 'Latest Server News');
+    if (!heading) return false;
+
+    let node = heading.nextElementSibling;
+    while (node && node.tagName !== 'H2') {
+      const next = node.nextElementSibling;
+      node.remove();
+      node = next;
+    }
+
+    const first = document.createElement('div');
+    first.className = 'news-item newest-news-item';
+    first.innerHTML = `<span class="news-date">${ARTICLE.date}</span><h3>${ARTICLE.title}<span class="new-badge">NEW!</span></h3><p>${ARTICLE.summary}</p><a href="news.html#${ARTICLE.id}">Read the full update →</a>`;
+
+    const second = document.createElement('div');
+    second.className = 'news-item';
+    second.innerHTML = `<span class="news-date">JUL 02, 2026</span><h3>Recent Plugin Updates and Additions</h3><p>New custom plugins and restored community tools improve protection, shops, activity visibility, Discord updates, mapping, and website statistics.</p><a href="news.html#plugins">Read the full update →</a>`;
+
+    heading.after(first, second);
+    return true;
+  }
+
+  function updateArchive() {
+    if (!/(^|\/)news\.html$/.test(location.pathname)) return false;
+    const archive = document.querySelector('.news-archive');
+    if (!archive) return false;
+
+    let newest = document.getElementById(ARTICLE.id);
+    if (!newest) {
+      newest = document.createElement('details');
+      newest.className = 'news-archive-item';
+      newest.id = ARTICLE.id;
+      newest.innerHTML = `<summary><span><span class="news-date">AUGUST 4, 2026</span><strong>${ARTICLE.title}<span class="new-badge">NEW!</span></strong></span><span class="archive-tag">Announcement</span></summary><div class="news-archive-body">${ARTICLE.body}</div>`;
+      archive.prepend(newest);
+    }
+
+    archive.querySelectorAll('details.news-archive-item').forEach(item => { item.open = item === newest; });
+    return true;
+  }
+
+  function apply() {
+    addStyles();
+    const homeDone = updateHome();
+    const archiveDone = updateArchive();
+    return homeDone || archiveDone;
+  }
+
+  function start() {
+    apply();
+    let attempts = 0;
+    const timer = setInterval(() => {
+      attempts += 1;
+      apply();
+      if (attempts >= 40) clearInterval(timer);
+    }, 250);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true });
+  else start();
+})();

--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -61,6 +61,42 @@
     return true;
   }
 
+  function getHashArticle(archive) {
+    if (!location.hash) return null;
+
+    let id;
+    try {
+      id = decodeURIComponent(location.hash.slice(1));
+    } catch {
+      id = location.hash.slice(1);
+    }
+
+    const target = document.getElementById(id);
+    return target instanceof HTMLDetailsElement && target.classList.contains('news-archive-item') && archive.contains(target)
+      ? target
+      : null;
+  }
+
+  function openArchiveArticle(archive, newest) {
+    const hashArticle = getHashArticle(archive);
+
+    if (hashArticle) {
+      archive.querySelectorAll('details.news-archive-item').forEach(item => {
+        item.open = item === hashArticle;
+      });
+      return;
+    }
+
+    // Only make the newest article the default when the URL is not targeting
+    // another archive entry. An unknown hash leaves the archive's existing
+    // open state untouched rather than overriding the requested destination.
+    if (!location.hash) {
+      archive.querySelectorAll('details.news-archive-item').forEach(item => {
+        item.open = item === newest;
+      });
+    }
+  }
+
   function updateArchive() {
     if (!/(^|\/)news\.html$/.test(location.pathname)) return true;
     const archive = document.querySelector('.news-archive');
@@ -79,7 +115,13 @@
       archive.prepend(newest);
     }
 
-    archive.querySelectorAll('details.news-archive-item').forEach(item => { item.open = item === newest; });
+    openArchiveArticle(archive, newest);
+
+    if (!archive.dataset.hashListenerAdded) {
+      window.addEventListener('hashchange', () => openArchiveArticle(archive, newest));
+      archive.dataset.hashListenerAdded = 'true';
+    }
+
     archive.dataset.retroNewsReady = 'true';
     return true;
   }

--- a/assets/script.js
+++ b/assets/script.js
@@ -126,7 +126,7 @@
       </section>
       <section class="box">
         <div class="box-title">Web Counter</div>
-        <div class="box-body center"><div class="hit-counter" data-counter>0000000</div><p class="small">unique visitors since reset</p></div>
+        <div class="box-body center"><div class="hit-counter" data-counter>0000000</div><p class="small">page views since reset</p></div>
       </section>
       <section class="box">
         <div class="box-title">Server Time</div>
@@ -160,25 +160,36 @@
     const counters = document.querySelectorAll('[data-counter]');
     if (!counters.length) return;
 
-    const countedKey = 'pinnacle-global-visitor-counted';
-    const firstVisit = !localStorage.getItem(countedKey);
     const base = 'https://api.counterapi.dev/v1/pinnaclesmp-org/website-visitors';
+    const lastValueKey = 'pinnacle-last-counter-value';
+
+    counters.forEach(counter => {
+      const caption = counter.parentElement?.querySelector('.small');
+      if (caption) caption.textContent = 'page views since reset';
+    });
+
+    const display = value => {
+      const safeValue = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+      counters.forEach(el => { el.textContent = String(safeValue).padStart(7, '0'); });
+    };
 
     try {
-      const response = await fetch(firstVisit ? `${base}/up` : `${base}/`, { cache: 'no-store' });
-      if (!response.ok) throw new Error('Counter request failed');
+      const response = await fetch(`${base}/up?t=${Date.now()}`, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Counter request failed: HTTP ${response.status}`);
       const data = await response.json();
-      const value = Number(data.count ?? data.value ?? 0);
-      if (firstVisit) localStorage.setItem(countedKey, 'true');
-      counters.forEach(el => { el.textContent = String(Number.isFinite(value) ? value : 0).padStart(7, '0'); });
-    } catch {
-      let value = Number(localStorage.getItem('pinnacle-local-counter') || 0);
-      if (firstVisit) {
-        value += 1;
-        localStorage.setItem('pinnacle-local-counter', String(value));
-        localStorage.setItem(countedKey, 'true');
-      }
-      counters.forEach(el => { el.textContent = String(value).padStart(7, '0'); });
+      const value = Number(data.count ?? data.value);
+      if (!Number.isFinite(value)) throw new Error('Counter returned an invalid value');
+      localStorage.setItem(lastValueKey, String(value));
+      localStorage.setItem('pinnacle-local-counter', String(value));
+      display(value);
+    } catch (error) {
+      console.warn('Shared page counter unavailable; continuing from the last displayed value.', error);
+      let value = Number(localStorage.getItem(lastValueKey) || localStorage.getItem('pinnacle-local-counter') || 0);
+      if (!Number.isFinite(value) || value < 0) value = 0;
+      value += 1;
+      localStorage.setItem(lastValueKey, String(value));
+      localStorage.setItem('pinnacle-local-counter', String(value));
+      display(value);
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -53,15 +53,10 @@
     <main class="content">
       <section class="box">
         <div class="box-body">
-          
 <h1>Welcome to <span class="rainbow">Pinnacle SMP!</span></h1>
-<div class="closed-status">
-  MEMBERSHIP NOTICE: Pinnacle SMP is not accepting additional new members at this time.
-</div>
+<div class="closed-status">MEMBERSHIP NOTICE: Pinnacle SMP is not accepting additional new members at this time.</div>
 <p>Pinnacle SMP is a small, established Minecraft community built around long-term survival worlds, trust, collaborative projects, memorable events, and a welcoming atmosphere. The community comes first and the server comes second.</p>
-<div class="callout center">
-  <strong>WHITELISTED • VANILLA+ • PAPER 26.2 • JAVA EDITION • 18+ ONLY</strong>
-</div>
+<div class="callout center"><strong>WHITELISTED • VANILLA+ • PAPER 26.2 • JAVA EDITION • 18+ ONLY</strong></div>
 <hr class="pixel-rule">
 <h2>Build Higher</h2>
 <p>Season 12 began in April 2026. Players are developing a community-built spawn town, connecting bases and projects, taking part in events, and allowing the world to grow organically over time.</p>
@@ -85,17 +80,17 @@
   </div>
 </div>
 <h2>Latest Server News</h2>
+<div class="news-item newest-news-item">
+  <span class="news-date">AUG 04, 2026</span>
+  <h3>Pinnacle SMP Website Gets a Retro '90s Redesign <span class="new-badge">NEW!</span></h3>
+  <p>The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.</p>
+  <a href="news.html#retro-redesign">Read the full update →</a>
+</div>
 <div class="news-item">
   <span class="news-date">JUL 02, 2026</span>
   <h3>Recent Plugin Updates and Additions</h3>
   <p>New custom plugins and restored community tools improve protection, shops, activity visibility, Discord updates, mapping, and website statistics.</p>
   <a href="news.html#plugins">Read the full update →</a>
-</div>
-<div class="news-item">
-  <span class="news-date">JUN 24, 2026</span>
-  <h3>Griefing Incident and Rollback</h3>
-  <p>The server was restored from its June 20 save after a griefing incident, and new FragGuard tools were introduced to investigate and reverse future damage.</p>
-  <a href="news.html#rollback">Read the full update →</a>
 </div>
 <h2>Upcoming Events</h2>
 <table class="event-table">
@@ -105,60 +100,20 @@
     <tr><td>Server Tour #2</td><td>IG-1</td><td>TBD</td><td>TBD</td></tr>
   </tbody>
 </table>
-
         </div>
       </section>
     </main>
-    
 <aside class="rightbar">
-  <section class="box">
-    <div class="box-title">Server Status</div>
-    <div class="box-body center">
-      <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
-      <p><strong data-player-count>— / 20</strong> players</p>
-      <p><span class="server-version" data-server-version>Paper 26.2</span></p>
-      <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
-      <div class="copy-row">
-        <button class="button-90s" type="button" data-copy-ip="pinnaclesmp.mcserv.fun">COPY IP</button>
-        <span class="copy-result" aria-live="polite"></span>
-      </div>
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Official Emblem</div>
-    <div class="box-body center">
-      <img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP mountain logo">
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Web Counter</div>
-    <div class="box-body center">
-      <div class="hit-counter" data-counter>0002012</div>
-      <p class="small">adventurers have entered</p>
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Eastern Time</div>
-    <div class="box-body center small" data-clock>Loading...</div>
-  </section>
-  <section class="box">
-    <div class="box-title">88×31 Zone</div>
-    <div class="box-body badge-row">
-      <img src="assets/badge-join.svg" alt="Pinnacle SMP">
-      <img src="assets/badge-html.svg" alt="Season 12 April 2026">
-      <img src="assets/badge-browser.svg" alt="Whitelisted Vanilla Plus">
-      <img src="assets/badge-under.svg" alt="Mature 18 plus only">
-    </div>
-  </section>
+  <section class="box"><div class="box-title">Server Status</div><div class="box-body center"><p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p><p><strong data-player-count>— / 20</strong> players</p><p><span class="server-version" data-server-version>Paper 26.2</span></p><p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p><div class="copy-row"><button class="button-90s" type="button" data-copy-ip="pinnaclesmp.mcserv.fun">COPY IP</button><span class="copy-result" aria-live="polite"></span></div></div></section>
+  <section class="box"><div class="box-title">Official Emblem</div><div class="box-body center"><img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP mountain logo"></div></section>
+  <section class="box"><div class="box-title">Web Counter</div><div class="box-body center"><div class="hit-counter" data-counter>0002012</div><p class="small">adventurers have entered</p></div></section>
+  <section class="box"><div class="box-title">Eastern Time</div><div class="box-body center small" data-clock>Loading...</div></section>
+  <section class="box"><div class="box-title">88×31 Zone</div><div class="box-body badge-row"><img src="assets/badge-join.svg" alt="Pinnacle SMP"><img src="assets/badge-html.svg" alt="Season 12 April 2026"><img src="assets/badge-browser.svg" alt="Whitelisted Vanilla Plus"><img src="assets/badge-under.svg" alt="Mature 18 plus only"></div></section>
 </aside>
-
   </div>
-  <footer class="footer">
-    <div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div>
-    <div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 4, 2026</div>
-    <div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div>
-  </footer>
+  <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 4, 2026</div><div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div></footer>
 </div>
 <script src="assets/script.js"></script>
+<script src="assets/retro-news-update.js"></script>
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -11,131 +11,25 @@
 <body>
 <div class="site-shell">
   <div class="top-strip"><span>PINNACLE SMP ONLINE NETWORK</span><span>SURFING SINCE 2012</span></div>
-  <header class="header">
-    <img class="logo" src="assets/logo.svg" alt="Pinnacle SMP Minecraft Community — Season 12">
-    <p class="tagline">BUILD • EXPLORE • MAKE FRIENDS • BUILD HIGHER</p>
-  </header>
+  <header class="header"><img class="logo" src="assets/logo.svg" alt="Pinnacle SMP Minecraft Community — Season 12"><p class="tagline">BUILD • EXPLORE • MAKE FRIENDS • BUILD HIGHER</p></header>
   <div class="marquee-box" aria-label="Server announcement"><span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY • APPLICATIONS TEMPORARILY CLOSED</span></div>
   <div class="main-grid">
     <aside class="sidebar">
-      <section class="box">
-        <div class="box-title">Main Menu</div>
-        <nav><ul class="nav-list"><li><a href="index.html">Home</a></li>
-<li><a href="about.html">About Pinnacle</a></li>
-<li><a href="season12.html">Season 12</a></li>
-<li><a href="news.html" class="active">Server News</a></li>
-<li><a href="members.html">Members</a></li>
-<li><a href="standings.html">Tournament Standings</a></li>
-<li><a href="gallery.html">Gallery</a></li>
-<li><a href="rules.html">Server Rules</a></li>
-<li><a href="faq.html">FAQs</a></li>
-<li><a href="links.html">Links & Voting</a></li>
-<li><a href="join.html">Join / Contact</a></li>
-<li><a href="guestbook.html">Guestbook</a></li></ul></nav>
-      </section>
-      <section class="box">
-        <div class="box-title">Quick Connect</div>
-        <div class="box-body small">
-          <p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p>
-          <p><strong>Capacity:</strong><br>20 players</p>
-          <p><strong>Edition:</strong><br>Java Edition</p>
-          <p><a href="https://map.pinnaclesmp.com/" target="_blank" rel="noopener">Live World Map</a></p>
-          <p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p>
-        </div>
-      </section>
-      <section class="box">
-        <div class="box-title">Cool Links</div>
-        <div class="box-body center">
-          <div class="webring"><a href="https://www.pinnaclesmp.org/" target="_blank" rel="noopener">« Live Site</a><strong>PINNACLE</strong><a href="links.html">Links »</a></div>
-        </div>
-      </section>
+      <section class="box"><div class="box-title">Main Menu</div><nav><ul class="nav-list"><li><a href="index.html">Home</a></li><li><a href="about.html">About Pinnacle</a></li><li><a href="season12.html">Season 12</a></li><li><a href="news.html" class="active">Server News</a></li><li><a href="members.html">Members</a></li><li><a href="standings.html">Tournament Standings</a></li><li><a href="gallery.html">Gallery</a></li><li><a href="rules.html">Server Rules</a></li><li><a href="faq.html">FAQs</a></li><li><a href="links.html">Links & Voting</a></li><li><a href="join.html">Join / Contact</a></li></ul></nav></section>
+      <section class="box"><div class="box-title">Quick Connect</div><div class="box-body small"><p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p><p><strong>Capacity:</strong><br>20 players</p><p><strong>Edition:</strong><br>Java Edition</p><p><a href="http://pinnaclesmp.mcserv.fun:1041/" target="_blank" rel="noopener">Live World Map</a></p><p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p></div></section>
+      <section class="box"><div class="box-title">Cool Links</div><div class="box-body center"><div class="webring"><a href="members.html">« Members</a><strong>PINNACLE</strong><a href="links.html#voting">Vote »</a></div></div></section>
     </aside>
-    <main class="content">
-      <section class="box">
-        <div class="box-body">
-          
-<h1>Server News Archive</h1>
-<article class="news-item" id="plugins">
-  <span class="news-date">JUL 02, 2026</span>
-  <h2>Recent Plugin Updates and Additions</h2>
-  <p>Pinnacle SMP expanded and restored its custom server toolset to improve protection, trading, activity information, Discord integration, and website statistics.</p>
-  <ul class="icon-list">
-    <li><strong>FragGuard:</strong> records block changes and helps staff investigate and roll back damage.</li>
-    <li><strong>FragStealers:</strong> provides player mailboxes and related community features.</li>
-    <li><strong>PinnacleAFK:</strong> clearly marks AFK players and supports safer AFK behavior.</li>
-    <li><strong>PinnacleShop:</strong> protects player shops from stealing and griefing.</li>
-    <li><strong>PinnacleStats:</strong> publishes server and player statistics.</li>
-    <li><strong>squaremap, DeathsToDiscord, and LastSeenToDiscord:</strong> restored mapping and Discord visibility tools.</li>
-  </ul>
-</article>
-<article class="news-item" id="rollback">
-  <span class="news-date">JUN 24, 2026</span>
-  <h2>Griefing Incident and Rollback</h2>
-  <p>After damage affected spawn and player bases, Pinnacle SMP was restored using the June 20 backup. The rollback protected the wider world while returning affected areas to a stable state.</p>
-  <p>The incident also led to the development of FragGuard, a custom logging and rollback system that records block placement, destruction, explosions, fire, fluid flow, and other world changes so staff can investigate future incidents more precisely.</p>
-</article>
-<article class="news-item" id="paper">
-  <span class="news-date">JUN 22, 2026</span>
-  <h2>Updated to Paper 26.2</h2>
-  <p>Pinnacle SMP moved back to Paper and updated to Paper 26.2: Chaos Cubed. Paper provides the performance and plugin support needed for the server’s protection, community, shop, activity, and Discord tools while keeping ordinary gameplay close to vanilla Minecraft.</p>
-</article>
-<div class="callout">
-  Visit the current <a href="https://www.pinnaclesmp.org/" target="_blank" rel="noopener">Pinnacle SMP website</a> for future announcements published after this packaged edition.
-</div>
-
-        </div>
-      </section>
-    </main>
-    
-<aside class="rightbar">
-  <section class="box">
-    <div class="box-title">Server Status</div>
-    <div class="box-body center">
-      <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
-      <p><strong data-player-count>— / 20</strong> players</p>
-      <p><span class="server-version" data-server-version>Paper 26.2</span></p>
-      <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
-      <div class="copy-row">
-        <button class="button-90s" type="button" data-copy-ip="pinnaclesmp.mcserv.fun">COPY IP</button>
-        <span class="copy-result" aria-live="polite"></span>
-      </div>
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Official Emblem</div>
-    <div class="box-body center">
-      <img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP mountain logo">
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Web Counter</div>
-    <div class="box-body center">
-      <div class="hit-counter" data-counter>0002012</div>
-      <p class="small">adventurers have entered</p>
-    </div>
-  </section>
-  <section class="box">
-    <div class="box-title">Eastern Time</div>
-    <div class="box-body center small" data-clock>Loading...</div>
-  </section>
-  <section class="box">
-    <div class="box-title">88×31 Zone</div>
-    <div class="box-body badge-row">
-      <img src="assets/badge-join.svg" alt="Pinnacle SMP">
-      <img src="assets/badge-html.svg" alt="Season 12 April 2026">
-      <img src="assets/badge-browser.svg" alt="Whitelisted Vanilla Plus">
-      <img src="assets/badge-under.svg" alt="Mature 18 plus only">
-    </div>
-  </section>
-</aside>
-
+    <main class="content"><section class="box"><div class="box-body"><h1>Server News Archive</h1><p>Loading the complete news archive…</p></div></section></main>
+    <aside class="rightbar">
+      <section class="box"><div class="box-title">Server Status</div><div class="box-body center"><p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p><p><strong data-player-count>— / 20</strong> players</p><p><span class="server-version" data-server-version>Paper 26.2</span></p><p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p></div></section>
+      <section class="box"><div class="box-title">Official Emblem</div><div class="box-body center"><img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP mountain logo"></div></section>
+      <section class="box"><div class="box-title">Web Counter</div><div class="box-body center"><div class="hit-counter" data-counter>0000000</div><p class="small">unique visitors since reset</p></div></section>
+      <section class="box"><div class="box-title">Server Time</div><div class="box-body center small" data-clock>Loading...</div></section>
+    </aside>
   </div>
-  <footer class="footer">
-    <div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div>
-    <div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 4, 2026</div>
-    <div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div>
-  </footer>
+  <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="index.html">Home</a> | <a href="members.html">Members</a></div><div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div></footer>
 </div>
 <script src="assets/script.js"></script>
+<script src="assets/retro-news-update.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a new August 4, 2026 server news article announcing the retro '90s website redesign.

Also:
- keeps exactly two articles on the homepage
- adds a blinking NEW! badge to the newest article
- ensures only the newest article opens automatically in the full news archive