### PR TITLE
Open membership applications and remove gallery flicker

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -18,12 +18,24 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      - name: Stage preview site
+        if: github.event.action != 'closed'
+        run: |
+          rm -rf _preview-site
+          mkdir -p _preview-site
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            --exclude '_preview-site/' \
+            --exclude 'github-pages-deploy-action-temp-deployment-folder/' \
+            ./ _preview-site/
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./
+          source-dir: ./_preview-site
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           pages-base-url: www.pinnaclesmp.org

--- a/assets/gallery-season-11.js
+++ b/assets/gallery-season-11.js
@@ -1,0 +1,57 @@
+(() => {
+  const cloudName = 'ds4p9jsuf';
+  const tag = 'Season 11';
+  const status = document.getElementById('gallery-status');
+  const grid = document.getElementById('season-gallery-grid');
+
+  if (!status || !grid) return;
+
+  const encodedTag = encodeURIComponent(tag);
+  const listUrl = `https://res.cloudinary.com/${cloudName}/image/list/${encodedTag}.json`;
+
+  fetch(listUrl)
+    .then((response) => {
+      if (!response.ok) throw new Error('Cloudinary gallery list failed to load.');
+      return response.json();
+    })
+    .then((data) => {
+      const resources = Array.isArray(data.resources) ? data.resources : [];
+      if (!resources.length) {
+        status.textContent = 'No screenshots have been added to this gallery yet.';
+        return;
+      }
+
+      status.textContent = '';
+      resources.forEach((image) => {
+        const publicId = image.public_id;
+        const format = image.format;
+        if (!publicId || !format) return;
+
+        const thumb = `https://res.cloudinary.com/${cloudName}/image/upload/w_500,h_350,c_fill,q_auto,f_auto/${publicId}.${format}`;
+        const full = `https://res.cloudinary.com/${cloudName}/image/upload/w_1800,q_auto,f_auto/${publicId}.${format}`;
+        const alt = publicId.replace(/[\/_-]+/g, ' ').trim();
+
+        const link = document.createElement('a');
+        link.className = 'season-gallery-item';
+        link.href = full;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+
+        const imageElement = document.createElement('img');
+        imageElement.src = thumb;
+        imageElement.alt = alt || 'Season 11 screenshot';
+        imageElement.loading = 'lazy';
+
+        link.appendChild(imageElement);
+        grid.appendChild(link);
+      });
+
+      if (!grid.children.length) {
+        status.textContent = 'No screenshots have been added to this gallery yet.';
+      }
+    })
+    .catch((error) => {
+      status.textContent = 'Sorry, we could not load the Season 11 gallery right now. Please try again later.';
+      console.error(error);
+    });
+})();

--- a/assets/script-base.js
+++ b/assets/script-base.js
@@ -1,0 +1,328 @@
+(function () {
+  if (window.__pinnacleMajorScriptLoaded) return;
+  window.__pinnacleMajorScriptLoaded = true;
+
+  const inProfiles = /\/profiles\//.test(location.pathname);
+  const prefix = inProfiles ? '../' : '';
+  const mapUrl = 'http://pinnaclesmp.mcserv.fun:1041/';
+  const statusApi = 'https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun';
+
+  if (!document.querySelector('link[data-major-update]')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = `${prefix}assets/major-update.css`;
+    link.dataset.majorUpdate = 'true';
+    document.head.appendChild(link);
+  }
+
+  const normalize = value => String(value ?? '').toLowerCase().replace(/[^a-z0-9_]/g, '');
+
+  function globalChanges() {
+    document.querySelectorAll('.top-strip span').forEach(el => {
+      if (el.textContent.trim() === 'SURFING SINCE 2012') el.textContent = 'ONLINE SINCE 2012';
+    });
+
+    document.querySelectorAll('a[href="guestbook.html"],a[href="../guestbook.html"]').forEach(a => {
+      (a.closest('li') || a).remove();
+    });
+
+    document.querySelectorAll('a').forEach(a => {
+      const text = a.textContent.trim();
+      if (/Live World Map|LIVE MAP|OPEN MAP|DIRECT MAP/i.test(text) || a.href.includes('map.pinnaclesmp.com')) {
+        a.href = mapUrl;
+      }
+    });
+
+    document.querySelectorAll('.box-title').forEach(el => {
+      if (el.textContent.trim() === 'Eastern Time') el.textContent = 'Server Time';
+    });
+
+    document.querySelectorAll('.webring').forEach(ring => {
+      const rootPrefix = inProfiles ? '../' : '';
+      ring.innerHTML = `<a href="${rootPrefix}members.html">« Members</a><strong>PINNACLE</strong><a href="${rootPrefix}links.html#voting">Vote »</a>`;
+    });
+
+    document.querySelectorAll('p.center a,.callout a').forEach(a => {
+      if (/CHECK LIVE RULES PAGE/i.test(a.textContent)) a.closest('p')?.remove();
+    });
+
+    const linksHeading = [...document.querySelectorAll('h1')].find(h => h.textContent.includes('Links, Forms & Voting'));
+    if (linksHeading) {
+      document.querySelectorAll('.link-card').forEach(card => {
+        const title = card.querySelector('h3')?.textContent.trim();
+        if (title === 'Official Website') card.remove();
+        if (title === 'Live World Map') {
+          const links = [...card.querySelectorAll('a')];
+          links.forEach((a, index) => {
+            if (index === 0) {
+              a.href = mapUrl;
+              a.textContent = 'OPEN MAP';
+            } else {
+              a.remove();
+            }
+          });
+        }
+      });
+    }
+
+    const joinHeading = [...document.querySelectorAll('h1')].find(h => h.textContent.includes('Join / Contact'));
+    if (joinHeading) {
+      const items = [...document.querySelectorAll('ol.rules li')];
+      items.find(li => /Learn about Pinnacle/i.test(li.textContent))?.remove();
+    }
+  }
+
+  function sharedSidebar(active) {
+    const items = [
+      ['index.html', 'Home'],
+      ['about.html', 'About Pinnacle'],
+      ['season12.html', 'Season 12'],
+      ['news.html', 'Server News'],
+      ['members.html', 'Members'],
+      ['standings.html', 'Tournament Standings'],
+      ['gallery.html', 'Gallery'],
+      ['rules.html', 'Server Rules'],
+      ['faq.html', 'FAQs'],
+      ['links.html', 'Links & Voting'],
+      ['join.html', 'Join / Contact']
+    ];
+
+    return `<aside class="sidebar">
+      <section class="box">
+        <div class="box-title">Main Menu</div>
+        <nav><ul class="nav-list">${items.map(([href, label]) => `<li><a href="${prefix}${href}"${href === active ? ' class="active"' : ''}>${label}</a></li>`).join('')}</ul></nav>
+      </section>
+      <section class="box">
+        <div class="box-title">Quick Connect</div>
+        <div class="box-body small">
+          <p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p>
+          <p><strong>Capacity:</strong><br>20 players</p>
+          <p><strong>Edition:</strong><br>Java Edition</p>
+          <p><a href="${mapUrl}" target="_blank" rel="noopener">Live World Map</a></p>
+          <p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p>
+        </div>
+      </section>
+      <section class="box">
+        <div class="box-title">Cool Links</div>
+        <div class="box-body center"><div class="webring"><a href="${prefix}members.html">« Members</a><strong>PINNACLE</strong><a href="${prefix}links.html#voting">Vote »</a></div></div>
+      </section>
+    </aside>`;
+  }
+
+  function rightbar() {
+    return `<aside class="rightbar">
+      <section class="box">
+        <div class="box-title">Server Status</div>
+        <div class="box-body center">
+          <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
+          <p><strong data-player-count>— / 20</strong> players</p>
+          <p><span class="server-version" data-server-version>Paper 26.2</span></p>
+          <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
+        </div>
+      </section>
+      <section class="box">
+        <div class="box-title">Official Emblem</div>
+        <div class="box-body center"><img class="official-logo" src="${prefix}assets/pinnacle-logo.png" alt="Official Pinnacle SMP logo"></div>
+      </section>
+      <section class="box">
+        <div class="box-title">Web Counter</div>
+        <div class="box-body center"><div class="hit-counter" data-counter>0000000</div><p class="small">page views since reset</p></div>
+      </section>
+      <section class="box">
+        <div class="box-title">Server Time</div>
+        <div class="box-body center small" data-clock>Loading...</div>
+      </section>
+    </aside>`;
+  }
+
+  function wrapLegacyPage(main, active, tagline) {
+    if (!main || document.querySelector('.profile-site-shell,.gallery-site-shell')) return;
+
+    document.querySelector('.site-header')?.remove();
+    document.querySelector('.site-warning-banner')?.remove();
+    document.querySelector('.site-footer')?.remove();
+    document.getElementById('particle-bg')?.remove();
+    document.body.classList.add('retro-wrapped-page');
+
+    const shell = document.createElement('div');
+    shell.className = `site-shell ${active === 'members.html' ? 'profile-site-shell' : 'gallery-site-shell'}`;
+    shell.innerHTML = `<div class="top-strip"><span>PINNACLE SMP ONLINE NETWORK</span><span>ONLINE SINCE 2012</span></div>
+      <header class="header"><img class="logo" src="${prefix}assets/logo.svg" alt="Pinnacle SMP"><p class="tagline">${tagline}</p></header>
+      <div class="marquee-box"><span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY</span></div>
+      <div class="main-grid">${sharedSidebar(active)}<main class="content"><section class="box"><div class="box-body" data-legacy-slot></div></section></main>${rightbar()}</div>
+      <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="${prefix}index.html">Home</a> | <a href="${prefix}members.html">Members</a></div></footer>`;
+
+    shell.querySelector('[data-legacy-slot]').appendChild(main);
+    document.body.prepend(shell);
+  }
+
+  async function visitorCounter() {
+    const counters = document.querySelectorAll('[data-counter]');
+    if (!counters.length) return;
+
+    const base = 'https://api.counterapi.dev/v1/pinnaclesmp-org/website-visitors';
+    const lastValueKey = 'pinnacle-last-counter-value';
+
+    counters.forEach(counter => {
+      const caption = counter.parentElement?.querySelector('.small');
+      if (caption) caption.textContent = 'page views since reset';
+    });
+
+    const display = value => {
+      const safeValue = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+      counters.forEach(el => { el.textContent = String(safeValue).padStart(7, '0'); });
+    };
+
+    try {
+      const response = await fetch(`${base}/up?t=${Date.now()}`, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Counter request failed: HTTP ${response.status}`);
+      const data = await response.json();
+      const value = Number(data.count ?? data.value);
+      if (!Number.isFinite(value)) throw new Error('Counter returned an invalid value');
+      localStorage.setItem(lastValueKey, String(value));
+      localStorage.setItem('pinnacle-local-counter', String(value));
+      display(value);
+    } catch (error) {
+      console.warn('Shared page counter unavailable; continuing from the last displayed value.', error);
+      let value = Number(localStorage.getItem(lastValueKey) || localStorage.getItem('pinnacle-local-counter') || 0);
+      if (!Number.isFinite(value) || value < 0) value = 0;
+      value += 1;
+      localStorage.setItem(lastValueKey, String(value));
+      localStorage.setItem('pinnacle-local-counter', String(value));
+      display(value);
+    }
+  }
+
+  function clock() {
+    const render = () => document.querySelectorAll('[data-clock]').forEach(el => {
+      el.textContent = new Date().toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZoneName: 'short'
+      });
+    });
+    render();
+    setInterval(render, 1000);
+  }
+
+  function paintStatus(data) {
+    const available = data.available !== false;
+    const state = !available ? 'STATUS UNAVAILABLE' : data.online ? 'ONLINE' : 'OFFLINE';
+    const onlineCount = data.online ? Number(data.playersOnline || 0) : 0;
+    const maxCount = Number(data.playersMax || 20);
+
+    document.querySelectorAll('[data-server-status]').forEach(el => { el.textContent = state; });
+    document.querySelectorAll('[data-player-count]').forEach(el => { el.textContent = `${onlineCount} / ${maxCount}`; });
+    document.querySelectorAll('[data-server-version]').forEach(el => { el.textContent = data.version || 'Paper 26.2'; });
+    document.querySelectorAll('[data-live-dot]').forEach(dot => {
+      dot.classList.remove('offline', 'unknown');
+      if (!available) dot.classList.add('unknown');
+      else if (!data.online) dot.classList.add('offline');
+    });
+
+    const onlinePlayers = new Set((data.onlinePlayers || []).map(normalize));
+    document.querySelectorAll('[data-member-card]').forEach(card => {
+      const candidates = String(card.dataset.usernames || card.dataset.username || '').split(',').map(normalize);
+      const online = candidates.some(name => onlinePlayers.has(name));
+      card.classList.toggle('is-online', online);
+      const label = card.querySelector('[data-member-status]');
+      if (label) label.textContent = online ? 'Online' : 'Offline';
+    });
+  }
+
+  function normalizePlayerList(value) {
+    if (Array.isArray(value)) {
+      return value.map(player => typeof player === 'string' ? player : player?.name).filter(Boolean);
+    }
+    if (value && typeof value === 'object') {
+      return Object.values(value).map(player => typeof player === 'string' ? player : player?.name).filter(Boolean);
+    }
+    return [];
+  }
+
+  async function fetchStatusDirectly() {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    try {
+      const response = await fetch(`${statusApi}?t=${Date.now()}`, {
+        cache: 'no-store',
+        signal: controller.signal,
+        mode: 'cors'
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      return {
+        available: true,
+        online: Boolean(data.online),
+        playersOnline: Number(data.players?.online || 0),
+        playersMax: Number(data.players?.max || 20),
+        onlinePlayers: normalizePlayerList(data.players?.list),
+        version: data.version || data.protocol?.name || 'Paper 26.2'
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async function status() {
+    try {
+      const service = window.PinnacleServerStatus;
+      const data = service?.fetchServerStatus
+        ? await service.fetchServerStatus({ force: true })
+        : await fetchStatusDirectly();
+      paintStatus(data);
+    } catch (error) {
+      console.warn('Unable to retrieve live Pinnacle SMP status.', error);
+      paintStatus({ available: false, online: false, playersOnline: 0, playersMax: 20, onlinePlayers: [], version: 'Paper 26.2' });
+    }
+  }
+
+  function profileOrGalleryWrap() {
+    if (inProfiles) {
+      wrapLegacyPage(document.querySelector('main.page'), 'members.html', 'PLAYER PROFILE • LIVE PINNACLESTATS');
+    } else if (/gallery-season-(11|12)\.html$/.test(location.pathname)) {
+      wrapLegacyPage(document.querySelector('main.container'), 'gallery.html', 'COMMUNITY SCREENSHOT ARCHIVE');
+    }
+  }
+
+  function start() {
+    profileOrGalleryWrap();
+    globalChanges();
+    window.PinnacleMajorContent?.rebuildNews();
+    window.PinnacleMajorContent?.rebuildMembers();
+    window.PinnacleMajorContent?.rebuildGalleryLanding();
+    globalChanges();
+
+    const year = document.querySelector('[data-year]');
+    if (year) year.textContent = new Date().getFullYear();
+
+    visitorCounter();
+    clock();
+    status();
+    setInterval(status, 60000);
+  }
+
+  function boot() {
+    const src = `${prefix}assets/major-content.js`;
+    if (window.PinnacleMajorContent) {
+      start();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = start;
+    script.onerror = start;
+    document.head.appendChild(script);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+})();

--- a/assets/script.js
+++ b/assets/script.js
@@ -4,9 +4,12 @@
 
   function replaceMembershipText(value) {
     return String(value)
-      .replace(/APPLICATIONS TEMPORARILY CLOSED/gi, 'NOW ACCEPTING NEW MEMBERS')
       .replace(/WHITELIST APPLICATIONS ARE TEMPORARILY CLOSED/gi, 'WHITELIST APPLICATIONS ARE OPEN')
+      .replace(/APPLICATIONS TEMPORARILY CLOSED/gi, 'NOW ACCEPTING NEW MEMBERS')
+      .replace(/APPLICATIONS ARE CLOSED/gi, 'APPLICATIONS ARE OPEN')
       .replace(/Pinnacle SMP is not accepting additional new members at this time\./gi, 'Pinnacle SMP is accepting new members.')
+      .replace(/Pinnacle SMP is not currently accepting new members\./gi, 'Pinnacle SMP is accepting new members.')
+      .replace(/Pinnacle SMP is not accepting new members\./gi, 'Pinnacle SMP is accepting new members.')
       .replace(/When Applications Reopen/gi, 'How to Apply');
   }
 
@@ -14,18 +17,19 @@
     document.querySelectorAll('.marquee-track').forEach(el => {
       let text = replaceMembershipText(el.textContent);
       if (!/ACCEPTING NEW MEMBERS/i.test(text)) text = `${text.trim()} • NOW ACCEPTING NEW MEMBERS`;
-      el.textContent = text;
+      if (el.textContent !== text) el.textContent = text;
     });
 
     document.querySelectorAll('.closed-status').forEach(el => {
-      if (/application|member/i.test(el.textContent)) {
-        el.textContent = 'WHITELIST APPLICATIONS ARE OPEN — PINNACLE SMP IS ACCEPTING NEW MEMBERS';
-        el.classList.add('membership-open-status');
-      }
+      if (!/application|member/i.test(el.textContent)) return;
+      const message = 'WHITELIST APPLICATIONS ARE OPEN — PINNACLE SMP IS ACCEPTING NEW MEMBERS';
+      if (el.textContent.trim() !== message) el.textContent = message;
+      el.classList.add('membership-open-status');
     });
 
     document.querySelectorAll('h2').forEach(el => {
-      el.textContent = replaceMembershipText(el.textContent);
+      const updated = replaceMembershipText(el.textContent);
+      if (updated !== el.textContent) el.textContent = updated;
     });
 
     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,328 +1,70 @@
-(function () {
-  if (window.__pinnacleMajorScriptLoaded) return;
-  window.__pinnacleMajorScriptLoaded = true;
+(() => {
+  const loader = document.currentScript;
+  let applyTimer = null;
 
-  const inProfiles = /\/profiles\//.test(location.pathname);
-  const prefix = inProfiles ? '../' : '';
-  const mapUrl = 'http://pinnaclesmp.mcserv.fun:1041/';
-  const statusApi = 'https://api.mcsrvstat.us/3/pinnaclesmp.mcserv.fun';
-
-  if (!document.querySelector('link[data-major-update]')) {
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = `${prefix}assets/major-update.css`;
-    link.dataset.majorUpdate = 'true';
-    document.head.appendChild(link);
+  function replaceMembershipText(value) {
+    return String(value)
+      .replace(/APPLICATIONS TEMPORARILY CLOSED/gi, 'NOW ACCEPTING NEW MEMBERS')
+      .replace(/WHITELIST APPLICATIONS ARE TEMPORARILY CLOSED/gi, 'WHITELIST APPLICATIONS ARE OPEN')
+      .replace(/Pinnacle SMP is not accepting additional new members at this time\./gi, 'Pinnacle SMP is accepting new members.')
+      .replace(/When Applications Reopen/gi, 'How to Apply');
   }
 
-  const normalize = value => String(value ?? '').toLowerCase().replace(/[^a-z0-9_]/g, '');
-
-  function globalChanges() {
-    document.querySelectorAll('.top-strip span').forEach(el => {
-      if (el.textContent.trim() === 'SURFING SINCE 2012') el.textContent = 'ONLINE SINCE 2012';
+  function applyMembershipOpen() {
+    document.querySelectorAll('.marquee-track').forEach(el => {
+      let text = replaceMembershipText(el.textContent);
+      if (!/ACCEPTING NEW MEMBERS/i.test(text)) text = `${text.trim()} • NOW ACCEPTING NEW MEMBERS`;
+      el.textContent = text;
     });
 
-    document.querySelectorAll('a[href="guestbook.html"],a[href="../guestbook.html"]').forEach(a => {
-      (a.closest('li') || a).remove();
-    });
-
-    document.querySelectorAll('a').forEach(a => {
-      const text = a.textContent.trim();
-      if (/Live World Map|LIVE MAP|OPEN MAP|DIRECT MAP/i.test(text) || a.href.includes('map.pinnaclesmp.com')) {
-        a.href = mapUrl;
+    document.querySelectorAll('.closed-status').forEach(el => {
+      if (/application|member/i.test(el.textContent)) {
+        el.textContent = 'WHITELIST APPLICATIONS ARE OPEN — PINNACLE SMP IS ACCEPTING NEW MEMBERS';
+        el.classList.add('membership-open-status');
       }
     });
 
-    document.querySelectorAll('.box-title').forEach(el => {
-      if (el.textContent.trim() === 'Eastern Time') el.textContent = 'Server Time';
+    document.querySelectorAll('h2').forEach(el => {
+      el.textContent = replaceMembershipText(el.textContent);
     });
 
-    document.querySelectorAll('.webring').forEach(ring => {
-      const rootPrefix = inProfiles ? '../' : '';
-      ring.innerHTML = `<a href="${rootPrefix}members.html">« Members</a><strong>PINNACLE</strong><a href="${rootPrefix}links.html#voting">Vote »</a>`;
-    });
-
-    document.querySelectorAll('p.center a,.callout a').forEach(a => {
-      if (/CHECK LIVE RULES PAGE/i.test(a.textContent)) a.closest('p')?.remove();
-    });
-
-    const linksHeading = [...document.querySelectorAll('h1')].find(h => h.textContent.includes('Links, Forms & Voting'));
-    if (linksHeading) {
-      document.querySelectorAll('.link-card').forEach(card => {
-        const title = card.querySelector('h3')?.textContent.trim();
-        if (title === 'Official Website') card.remove();
-        if (title === 'Live World Map') {
-          const links = [...card.querySelectorAll('a')];
-          links.forEach((a, index) => {
-            if (index === 0) {
-              a.href = mapUrl;
-              a.textContent = 'OPEN MAP';
-            } else {
-              a.remove();
-            }
-          });
-        }
-      });
-    }
-
-    const joinHeading = [...document.querySelectorAll('h1')].find(h => h.textContent.includes('Join / Contact'));
-    if (joinHeading) {
-      const items = [...document.querySelectorAll('ol.rules li')];
-      items.find(li => /Learn about Pinnacle/i.test(li.textContent))?.remove();
-    }
-  }
-
-  function sharedSidebar(active) {
-    const items = [
-      ['index.html', 'Home'],
-      ['about.html', 'About Pinnacle'],
-      ['season12.html', 'Season 12'],
-      ['news.html', 'Server News'],
-      ['members.html', 'Members'],
-      ['standings.html', 'Tournament Standings'],
-      ['gallery.html', 'Gallery'],
-      ['rules.html', 'Server Rules'],
-      ['faq.html', 'FAQs'],
-      ['links.html', 'Links & Voting'],
-      ['join.html', 'Join / Contact']
-    ];
-
-    return `<aside class="sidebar">
-      <section class="box">
-        <div class="box-title">Main Menu</div>
-        <nav><ul class="nav-list">${items.map(([href, label]) => `<li><a href="${prefix}${href}"${href === active ? ' class="active"' : ''}>${label}</a></li>`).join('')}</ul></nav>
-      </section>
-      <section class="box">
-        <div class="box-title">Quick Connect</div>
-        <div class="box-body small">
-          <p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p>
-          <p><strong>Capacity:</strong><br>20 players</p>
-          <p><strong>Edition:</strong><br>Java Edition</p>
-          <p><a href="${mapUrl}" target="_blank" rel="noopener">Live World Map</a></p>
-          <p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p>
-        </div>
-      </section>
-      <section class="box">
-        <div class="box-title">Cool Links</div>
-        <div class="box-body center"><div class="webring"><a href="${prefix}members.html">« Members</a><strong>PINNACLE</strong><a href="${prefix}links.html#voting">Vote »</a></div></div>
-      </section>
-    </aside>`;
-  }
-
-  function rightbar() {
-    return `<aside class="rightbar">
-      <section class="box">
-        <div class="box-title">Server Status</div>
-        <div class="box-body center">
-          <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
-          <p><strong data-player-count>— / 20</strong> players</p>
-          <p><span class="server-version" data-server-version>Paper 26.2</span></p>
-          <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
-        </div>
-      </section>
-      <section class="box">
-        <div class="box-title">Official Emblem</div>
-        <div class="box-body center"><img class="official-logo" src="${prefix}assets/pinnacle-logo.png" alt="Official Pinnacle SMP logo"></div>
-      </section>
-      <section class="box">
-        <div class="box-title">Web Counter</div>
-        <div class="box-body center"><div class="hit-counter" data-counter>0000000</div><p class="small">page views since reset</p></div>
-      </section>
-      <section class="box">
-        <div class="box-title">Server Time</div>
-        <div class="box-body center small" data-clock>Loading...</div>
-      </section>
-    </aside>`;
-  }
-
-  function wrapLegacyPage(main, active, tagline) {
-    if (!main || document.querySelector('.profile-site-shell,.gallery-site-shell')) return;
-
-    document.querySelector('.site-header')?.remove();
-    document.querySelector('.site-warning-banner')?.remove();
-    document.querySelector('.site-footer')?.remove();
-    document.getElementById('particle-bg')?.remove();
-    document.body.classList.add('retro-wrapped-page');
-
-    const shell = document.createElement('div');
-    shell.className = `site-shell ${active === 'members.html' ? 'profile-site-shell' : 'gallery-site-shell'}`;
-    shell.innerHTML = `<div class="top-strip"><span>PINNACLE SMP ONLINE NETWORK</span><span>ONLINE SINCE 2012</span></div>
-      <header class="header"><img class="logo" src="${prefix}assets/logo.svg" alt="Pinnacle SMP"><p class="tagline">${tagline}</p></header>
-      <div class="marquee-box"><span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY</span></div>
-      <div class="main-grid">${sharedSidebar(active)}<main class="content"><section class="box"><div class="box-body" data-legacy-slot></div></section></main>${rightbar()}</div>
-      <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="${prefix}index.html">Home</a> | <a href="${prefix}members.html">Members</a></div></footer>`;
-
-    shell.querySelector('[data-legacy-slot]').appendChild(main);
-    document.body.prepend(shell);
-  }
-
-  async function visitorCounter() {
-    const counters = document.querySelectorAll('[data-counter]');
-    if (!counters.length) return;
-
-    const base = 'https://api.counterapi.dev/v1/pinnaclesmp-org/website-visitors';
-    const lastValueKey = 'pinnacle-last-counter-value';
-
-    counters.forEach(counter => {
-      const caption = counter.parentElement?.querySelector('.small');
-      if (caption) caption.textContent = 'page views since reset';
-    });
-
-    const display = value => {
-      const safeValue = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
-      counters.forEach(el => { el.textContent = String(safeValue).padStart(7, '0'); });
-    };
-
-    try {
-      const response = await fetch(`${base}/up?t=${Date.now()}`, { cache: 'no-store' });
-      if (!response.ok) throw new Error(`Counter request failed: HTTP ${response.status}`);
-      const data = await response.json();
-      const value = Number(data.count ?? data.value);
-      if (!Number.isFinite(value)) throw new Error('Counter returned an invalid value');
-      localStorage.setItem(lastValueKey, String(value));
-      localStorage.setItem('pinnacle-local-counter', String(value));
-      display(value);
-    } catch (error) {
-      console.warn('Shared page counter unavailable; continuing from the last displayed value.', error);
-      let value = Number(localStorage.getItem(lastValueKey) || localStorage.getItem('pinnacle-local-counter') || 0);
-      if (!Number.isFinite(value) || value < 0) value = 0;
-      value += 1;
-      localStorage.setItem(lastValueKey, String(value));
-      localStorage.setItem('pinnacle-local-counter', String(value));
-      display(value);
-    }
-  }
-
-  function clock() {
-    const render = () => document.querySelectorAll('[data-clock]').forEach(el => {
-      el.textContent = new Date().toLocaleString('en-US', {
-        timeZone: 'America/New_York',
-        weekday: 'short',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        timeZoneName: 'short'
-      });
-    });
-    render();
-    setInterval(render, 1000);
-  }
-
-  function paintStatus(data) {
-    const available = data.available !== false;
-    const state = !available ? 'STATUS UNAVAILABLE' : data.online ? 'ONLINE' : 'OFFLINE';
-    const onlineCount = data.online ? Number(data.playersOnline || 0) : 0;
-    const maxCount = Number(data.playersMax || 20);
-
-    document.querySelectorAll('[data-server-status]').forEach(el => { el.textContent = state; });
-    document.querySelectorAll('[data-player-count]').forEach(el => { el.textContent = `${onlineCount} / ${maxCount}`; });
-    document.querySelectorAll('[data-server-version]').forEach(el => { el.textContent = data.version || 'Paper 26.2'; });
-    document.querySelectorAll('[data-live-dot]').forEach(dot => {
-      dot.classList.remove('offline', 'unknown');
-      if (!available) dot.classList.add('unknown');
-      else if (!data.online) dot.classList.add('offline');
-    });
-
-    const onlinePlayers = new Set((data.onlinePlayers || []).map(normalize));
-    document.querySelectorAll('[data-member-card]').forEach(card => {
-      const candidates = String(card.dataset.usernames || card.dataset.username || '').split(',').map(normalize);
-      const online = candidates.some(name => onlinePlayers.has(name));
-      card.classList.toggle('is-online', online);
-      const label = card.querySelector('[data-member-status]');
-      if (label) label.textContent = online ? 'Online' : 'Offline';
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+    nodes.forEach(node => {
+      if (node.parentElement?.closest('script,style')) return;
+      const updated = replaceMembershipText(node.nodeValue);
+      if (updated !== node.nodeValue) node.nodeValue = updated;
     });
   }
 
-  function normalizePlayerList(value) {
-    if (Array.isArray(value)) {
-      return value.map(player => typeof player === 'string' ? player : player?.name).filter(Boolean);
+  const style = document.createElement('style');
+  style.textContent = `
+    .membership-open-status {
+      background: #dff5d5 !important;
+      border-color: #5b8a4a !important;
+      color: #153c0d !important;
     }
-    if (value && typeof value === 'object') {
-      return Object.values(value).map(player => typeof player === 'string' ? player : player?.name).filter(Boolean);
-    }
-    return [];
-  }
+  `;
+  document.head.appendChild(style);
 
-  async function fetchStatusDirectly() {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10000);
-    try {
-      const response = await fetch(`${statusApi}?t=${Date.now()}`, {
-        cache: 'no-store',
-        signal: controller.signal,
-        mode: 'cors'
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = await response.json();
-      return {
-        available: true,
-        online: Boolean(data.online),
-        playersOnline: Number(data.players?.online || 0),
-        playersMax: Number(data.players?.max || 20),
-        onlinePlayers: normalizePlayerList(data.players?.list),
-        version: data.version || data.protocol?.name || 'Paper 26.2'
-      };
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  async function status() {
-    try {
-      const service = window.PinnacleServerStatus;
-      const data = service?.fetchServerStatus
-        ? await service.fetchServerStatus({ force: true })
-        : await fetchStatusDirectly();
-      paintStatus(data);
-    } catch (error) {
-      console.warn('Unable to retrieve live Pinnacle SMP status.', error);
-      paintStatus({ available: false, online: false, playersOnline: 0, playersMax: 20, onlinePlayers: [], version: 'Paper 26.2' });
-    }
-  }
-
-  function profileOrGalleryWrap() {
-    if (inProfiles) {
-      wrapLegacyPage(document.querySelector('main.page'), 'members.html', 'PLAYER PROFILE • LIVE PINNACLESTATS');
-    } else if (/gallery-season-(11|12)\.html$/.test(location.pathname)) {
-      wrapLegacyPage(document.querySelector('main.container'), 'gallery.html', 'COMMUNITY SCREENSHOT ARCHIVE');
-    }
-  }
-
-  function start() {
-    profileOrGalleryWrap();
-    globalChanges();
-    window.PinnacleMajorContent?.rebuildNews();
-    window.PinnacleMajorContent?.rebuildMembers();
-    window.PinnacleMajorContent?.rebuildGalleryLanding();
-    globalChanges();
-
-    const year = document.querySelector('[data-year]');
-    if (year) year.textContent = new Date().getFullYear();
-
-    visitorCounter();
-    clock();
-    status();
-    setInterval(status, 60000);
-  }
-
-  function boot() {
-    const src = `${prefix}assets/major-content.js`;
-    if (window.PinnacleMajorContent) {
-      start();
-      return;
-    }
-    const script = document.createElement('script');
-    script.src = src;
-    script.onload = start;
-    script.onerror = start;
-    document.head.appendChild(script);
-  }
+  const scheduleApply = () => {
+    clearTimeout(applyTimer);
+    applyTimer = setTimeout(applyMembershipOpen, 0);
+  };
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', boot, { once: true });
+    document.addEventListener('DOMContentLoaded', applyMembershipOpen, { once: true });
   } else {
-    boot();
+    applyMembershipOpen();
   }
+
+  const observer = new MutationObserver(scheduleApply);
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+
+  const baseScript = document.createElement('script');
+  baseScript.src = new URL('script-base.js', loader.src).href;
+  baseScript.onload = applyMembershipOpen;
+  baseScript.onerror = applyMembershipOpen;
+  document.head.appendChild(baseScript);
 })();

--- a/gallery-season-11.html
+++ b/gallery-season-11.html
@@ -1,107 +1,131 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Season 11 Gallery | Pinnacle SMP</title><link rel="stylesheet" href="assets/light-theme.css" />
-<style>
-*{box-sizing:border-box}
-body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;background:var(--bg-soft)}
-.site-header{position:sticky;top:0;z-index:50;backdrop-filter:none;background:var(--nav-bg);border-bottom:1px solid var(--btn-secondary-bg)}
-.nav-wrap{width:min(calc(100% - 32px),1100px);margin:0 auto;display:flex;align-items:center;justify-content:space-between;gap:20px;min-height:82px}
-.brand{display:flex;align-items:center;gap:14px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;text-decoration:none;color:var(--text)}
-.brand-logo{width:46px;height:46px;object-fit:contain;flex-shrink:0}
-.brand span{font-size:1rem}
-.menu-toggle{display:none;align-items:center;justify-content:center;gap:8px;min-height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(141,181,255,.34);background:var(--btn-secondary-bg);color:var(--text);font-weight:700;font:inherit;cursor:pointer}
-#mobile-nav .nav-buttons{display:flex;flex-wrap:wrap;gap:8px}
-.nav-buttons .btn{padding:0 15px;min-height:42px;border-radius:12px;border:1px solid var(--line);background:var(--btn-secondary-bg);color:var(--text);font-weight:700;text-decoration:none;display:inline-flex;align-items:center;justify-content:center;transition:transform .18s ease,background .2s ease,border-color .2s ease,box-shadow .2s ease}
-.nav-buttons .btn:hover,.nav-buttons .btn:focus-visible{background:var(--btn-secondary-hover);color:var(--text);outline:none}
-.container{width:min(calc(100% - 32px),1100px);margin:0 auto;padding:36px 0 54px}
-.panel{background:var(--panel);border:1px solid var(--line);border-radius:24px;padding:28px;box-shadow:var(--shadow)}
-@media(max-width:860px){.nav-wrap{min-height:unset;padding:12px 0;flex-wrap:wrap}.menu-toggle{display:inline-flex}#mobile-nav{display:none;width:100%}.site-header.nav-open #mobile-nav{display:block}#mobile-nav .nav-buttons{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;margin-top:10px}.nav-buttons .btn{width:100%;min-height:40px;padding:0 13px;font-size:.9rem}}
-</style></head><body>
-  <canvas id="particle-bg" aria-hidden="true"></canvas>
-<header class="site-header">
-    <div class="container nav-wrap">
-      <div class="brand-group">
-        <a href="index.html#home" class="brand">
-          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
-          <span>Pinnacle SMP</span>
-        </a>
-        <a id="server-status-badge" class="brand-status" href="members.html" aria-live="polite">
-          <span class="status-dot brand-status-dot" aria-hidden="true"></span>
-          <span id="server-status-text">Checking…</span>
-        </a>
-      </div>
-      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
-
-      <nav id="mobile-nav" aria-label="Main navigation">
-        <div class="cta-row nav-buttons" role="list">
-              <a class="btn btn-secondary hover-lift" href="index.html#home">Home</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#news">Server News</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#events">Events</a>
-              <a class="btn btn-secondary hover-lift" href="rules.html">Server Rules</a>
-              <a class="btn btn-secondary hover-lift" href="gallery.html">Gallery</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#join">Join</a>
-        </div>
-      </nav>
-    </div>
-  </header>
-  <section class="site-warning-banner" role="status" aria-label="Membership notice">
-    <div class="site-warning-banner__inner">Pinnacle SMP is not accepting any more new members at this time. Thank you for your interest in joining us and your understanding on this matter.</div>
-  </section>
-<main class="container"><section class="panel"><h1>Season 11 Gallery</h1><p>A visual archive of community moments from Pinnacle SMP Season 11.</p><p id="gallery-status">Loading screenshots…</p><div id="season-gallery-grid" class="season-gallery-grid" aria-live="polite"></div></section></main>
-
-  <footer class="site-footer">
-    <div class="container footer-grid">
-      <div class="footer-brand">
-        <div class="brand" style="margin-bottom: 12px;">
-          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
-          <span>Pinnacle SMP</span>
-        </div>
-        <p>
-          The Pinnacle SMP server is in no way affiliated with Mojang Studios or Microsoft,
-          nor should it be considered endorsed by either company.
-        </p>
-      </div>
-
-      <div class="footer-col">
-        <h4>Membership</h4>
-        <div class="footer-links">
-          <a href="about-us.html">About Us</a>
-          <a href="members.html">Members</a>
-          <a href="vote-history.html">Vote History</a>
-          <a href="tournament-standings.html">Tournament Standings</a>
-          <a href="rules.html">Server Rules</a>
-          <a href="index.html#news">Server News</a>
-        </div>
-      </div>
-
-      <div class="footer-col">
-        <h4>Contact</h4>
-        <div class="footer-links">
-          <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener noreferrer">Contact Us</a>
-          <a href="faq.html">FAQs</a>
-          <a href="https://forms.gle/2Wp7HmhhMbxEsafM7" target="_blank" rel="noopener noreferrer">Ban Appeal</a>
-          <a href="https://forms.gle/gB6qyvpkKUXfC9jr9" target="_blank" rel="noopener noreferrer">Plugin Suggestions</a>
-          <a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener noreferrer">Whitelist Application</a>
-        </div>
-      </div>
-
-      <div class="footer-col">
-        <h4>External</h4>
-        <div class="footer-links">
-          <a href="vote-links.html">Vote Links</a>
-          <a href="https://www.minecraft.net/en-us/minecraft-tips-for-beginners#getting_started" target="_blank" rel="noopener noreferrer">How to Play</a>
-          <a href="https://www.minecraft.net/" target="_blank" rel="noopener noreferrer">Minecraft.net</a>
-          <a href="https://www.bisecthosting.com/donate/299b5130" target="_blank" rel="noopener noreferrer">Server Donation</a>
-        </div>
-      </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Browse the Pinnacle SMP Season 11 screenshot archive.">
+  <title>Season 11 Gallery | Pinnacle SMP</title>
+  <link rel="icon" href="assets/diamond.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="assets/major-update.css" data-major-update>
+</head>
+<body class="retro-wrapped-page">
+  <div class="site-shell gallery-site-shell">
+    <div class="top-strip">
+      <span>PINNACLE SMP ONLINE NETWORK</span>
+      <span>ONLINE SINCE 2012</span>
     </div>
 
-    <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved. v. 108.6220540
+    <header class="header">
+      <img class="logo" src="assets/logo.svg" alt="Pinnacle SMP">
+      <p class="tagline">COMMUNITY SCREENSHOT ARCHIVE</p>
+    </header>
+
+    <div class="marquee-box" aria-label="Server announcement">
+      <span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY • NOW ACCEPTING NEW MEMBERS</span>
     </div>
-  </footer>
-<script>(()=>{const h=document.querySelector('.site-header');const t=document.querySelector('.menu-toggle');const n=document.getElementById('mobile-nav');if(h&&t&&n){const c=()=>{h.classList.remove('nav-open');t.setAttribute('aria-expanded','false')};t.addEventListener('click',()=>{const o=h.classList.toggle('nav-open');t.setAttribute('aria-expanded',String(o))});n.querySelectorAll('a').forEach((l)=>l.addEventListener('click',c));window.addEventListener('resize',()=>{if(window.innerWidth>860)c()});}
-const cloudName='ds4p9jsuf';const tag='Season 11';const encodedTag=encodeURIComponent(tag);const listUrl=`https://res.cloudinary.com/${cloudName}/image/list/${encodedTag}.json`;const status=document.getElementById('gallery-status');const grid=document.getElementById('season-gallery-grid');
-fetch(listUrl).then(r=>{if(!r.ok) throw new Error('Cloudinary gallery list failed to load.'); return r.json();}).then(data=>{const resources=Array.isArray(data.resources)?data.resources:[];if(resources.length===0){status.textContent='No screenshots have been added to this gallery yet.';return;}status.textContent='';resources.forEach((image)=>{const publicId=image.public_id;const format=image.format;if(!publicId||!format)return;const thumb=`https://res.cloudinary.com/${cloudName}/image/upload/w_500,h_350,c_fill,q_auto,f_auto/${publicId}.${format}`;const full=`https://res.cloudinary.com/${cloudName}/image/upload/w_1800,q_auto,f_auto/${publicId}.${format}`;const alt=publicId.replace(/[\/_-]+/g,' ').trim();const a=document.createElement('a');a.className='season-gallery-item';a.href=full;a.target='_blank';a.rel='noopener noreferrer';const img=document.createElement('img');img.src=thumb;img.alt=alt||'Season 11 screenshot';img.loading='lazy';a.appendChild(img);grid.appendChild(a);});if(!grid.children.length){status.textContent='No screenshots have been added to this gallery yet.';}}).catch((error)=>{status.textContent='Sorry, we could not load the Season 11 gallery right now. Please try again later.';console.error(error);});})();</script>
-  <script src="assets/server-status.js"></script>
-  <script src="assets/server-status-badge.js"></script>
-  <script src="assets/particles.js"></script>
-</body></html>
+
+    <div class="main-grid">
+      <aside class="sidebar">
+        <section class="box">
+          <div class="box-title">Main Menu</div>
+          <nav>
+            <ul class="nav-list">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="about.html">About Pinnacle</a></li>
+              <li><a href="season12.html">Season 12</a></li>
+              <li><a href="news.html">Server News</a></li>
+              <li><a href="members.html">Members</a></li>
+              <li><a href="standings.html">Tournament Standings</a></li>
+              <li><a href="gallery.html" class="active">Gallery</a></li>
+              <li><a href="rules.html">Server Rules</a></li>
+              <li><a href="faq.html">FAQs</a></li>
+              <li><a href="links.html">Links &amp; Voting</a></li>
+              <li><a href="join.html">Join / Contact</a></li>
+            </ul>
+          </nav>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Quick Connect</div>
+          <div class="box-body small">
+            <p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p>
+            <p><strong>Capacity:</strong><br>20 players</p>
+            <p><strong>Edition:</strong><br>Java Edition</p>
+            <p><a href="http://pinnaclesmp.mcserv.fun:1041/" target="_blank" rel="noopener">Live World Map</a></p>
+            <p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Cool Links</div>
+          <div class="box-body center">
+            <div class="webring">
+              <a href="members.html">« Members</a>
+              <strong>PINNACLE</strong>
+              <a href="links.html#voting">Vote »</a>
+            </div>
+          </div>
+        </section>
+      </aside>
+
+      <main class="content">
+        <section class="box">
+          <div class="box-title">Season 11 Screenshot Archive</div>
+          <div class="box-body">
+            <div class="gallery-breadcrumbs">
+              <a href="gallery.html">Gallery</a>
+              <span aria-hidden="true">›</span>
+              <span aria-current="page">Season 11</span>
+            </div>
+            <h1>Season 11 Gallery</h1>
+            <p>A visual archive of community moments from Pinnacle SMP Season 11.</p>
+            <p id="gallery-status">Loading screenshots…</p>
+            <div id="season-gallery-grid" class="season-gallery-grid" aria-live="polite"></div>
+          </div>
+        </section>
+      </main>
+
+      <aside class="rightbar">
+        <section class="box">
+          <div class="box-title">Server Status</div>
+          <div class="box-body center">
+            <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
+            <p><strong data-player-count>— / 20</strong> players</p>
+            <p><span class="server-version" data-server-version>Paper 26.2</span></p>
+            <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Official Emblem</div>
+          <div class="box-body center">
+            <img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP logo">
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Web Counter</div>
+          <div class="box-body center">
+            <div class="hit-counter" data-counter>0000000</div>
+            <p class="small">page views since reset</p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Server Time</div>
+          <div class="box-body center small" data-clock>Loading...</div>
+        </section>
+      </aside>
+    </div>
+
+    <footer class="footer">
+      <div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div>
+      <div><a href="gallery.html">Gallery</a> | <a href="gallery-season-11.html">Season 11</a> | <a href="gallery-season-12.html">Season 12</a></div>
+      <div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div>
+    </footer>
+  </div>
+
+  <script src="assets/gallery-season-11.js"></script>
+  <script src="assets/script.js"></script>
+</body>
+</html>

--- a/gallery-season-12.html
+++ b/gallery-season-12.html
@@ -1,110 +1,129 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Season 12 Gallery | Pinnacle SMP</title><link rel="stylesheet" href="assets/light-theme.css" />
-<style>
-*{box-sizing:border-box}
-body{margin:0;color:var(--text);font-family:Inter,ui-sans-serif,system-ui;background:var(--bg-soft)}
-.site-header{position:sticky;top:0;z-index:50;backdrop-filter:none;background:var(--nav-bg);border-bottom:1px solid var(--btn-secondary-bg)}
-.nav-wrap{width:min(calc(100% - 32px),1100px);margin:0 auto;display:flex;align-items:center;justify-content:space-between;gap:20px;min-height:82px}
-.brand{display:flex;align-items:center;gap:14px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;text-decoration:none;color:var(--text)}
-.brand-logo{width:46px;height:46px;object-fit:contain;flex-shrink:0}
-.brand span{font-size:1rem}
-.menu-toggle{display:none;align-items:center;justify-content:center;gap:8px;min-height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(141,181,255,.34);background:var(--btn-secondary-bg);color:var(--text);font-weight:700;font:inherit;cursor:pointer}
-#mobile-nav .nav-buttons{display:flex;flex-wrap:wrap;gap:8px}
-.nav-buttons .btn{padding:0 15px;min-height:42px;border-radius:12px;border:1px solid var(--line);background:var(--btn-secondary-bg);color:var(--text);font-weight:700;text-decoration:none;display:inline-flex;align-items:center;justify-content:center;transition:transform .18s ease,background .2s ease,border-color .2s ease,box-shadow .2s ease}
-.nav-buttons .btn:hover,.nav-buttons .btn:focus-visible{background:var(--btn-secondary-hover);color:var(--text);outline:none}
-.container{width:min(calc(100% - 32px),1100px);margin:0 auto;padding:36px 0 54px}
-.panel{background:var(--panel);border:1px solid var(--line);border-radius:24px;padding:28px;box-shadow:var(--shadow)}
-.gallery-breadcrumbs{display:flex;flex-wrap:wrap;gap:10px;margin:0 0 18px;color:var(--muted)}
-.gallery-breadcrumbs a{color:var(--text);text-decoration:none}
-.gallery-breadcrumbs a:hover{text-decoration:underline}
-@media(max-width:860px){.nav-wrap{min-height:unset;padding:12px 0;flex-wrap:wrap}.menu-toggle{display:inline-flex}#mobile-nav{display:none;width:100%}.site-header.nav-open #mobile-nav{display:block}#mobile-nav .nav-buttons{width:100%;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;margin-top:10px}.nav-buttons .btn{width:100%;min-height:40px;padding:0 13px;font-size:.9rem}}
-</style></head><body>
-  <canvas id="particle-bg" aria-hidden="true"></canvas>
-<header class="site-header">
-    <div class="container nav-wrap">
-      <div class="brand-group">
-        <a href="index.html#home" class="brand">
-          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
-          <span>Pinnacle SMP</span>
-        </a>
-        <a id="server-status-badge" class="brand-status" href="members.html" aria-live="polite">
-          <span class="status-dot brand-status-dot" aria-hidden="true"></span>
-          <span id="server-status-text">Checking…</span>
-        </a>
-      </div>
-      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-nav">Menu</button>
-
-      <nav id="mobile-nav" aria-label="Main navigation">
-        <div class="cta-row nav-buttons" role="list">
-              <a class="btn btn-secondary hover-lift" href="index.html#home">Home</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#news">Server News</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#events">Events</a>
-              <a class="btn btn-secondary hover-lift" href="rules.html">Server Rules</a>
-              <a class="btn btn-secondary hover-lift" href="gallery.html">Gallery</a>
-              <a class="btn btn-secondary hover-lift" href="index.html#join">Join</a>
-        </div>
-      </nav>
-    </div>
-  </header>
-  <section class="site-warning-banner" role="status" aria-label="Membership notice">
-    <div class="site-warning-banner__inner">Pinnacle SMP is not accepting any more new members at this time. Thank you for your interest in joining us and your understanding on this matter.</div>
-  </section>
-<main class="container"><section class="panel"><nav id="gallery-breadcrumbs" class="gallery-breadcrumbs" aria-label="Breadcrumb"></nav><h1 id="gallery-title">Season 12 Gallery</h1><p id="gallery-description">A visual archive of community moments from Pinnacle SMP Season 12.</p><p id="gallery-status">Loading screenshots…</p><div id="folder-grid" class="gallery-list" aria-live="polite"></div><div id="season-gallery-grid" class="season-gallery-grid" aria-live="polite"></div></section></main>
-
-  <footer class="site-footer">
-    <div class="container footer-grid">
-      <div class="footer-brand">
-        <div class="brand" style="margin-bottom: 12px;">
-          <img class="brand-logo" src="https://res.cloudinary.com/ds4p9jsuf/image/upload/v1780430105/94ED434F-0A09-4D1B-9E18-B5B4B9248641_fbtaz7.png" alt="Pinnacle SMP Season 12 logo" />
-          <span>Pinnacle SMP</span>
-        </div>
-        <p>
-          The Pinnacle SMP server is in no way affiliated with Mojang Studios or Microsoft,
-          nor should it be considered endorsed by either company.
-        </p>
-      </div>
-
-      <div class="footer-col">
-        <h4>Membership</h4>
-        <div class="footer-links">
-          <a href="about-us.html">About Us</a>
-          <a href="members.html">Members</a>
-          <a href="vote-history.html">Vote History</a>
-          <a href="tournament-standings.html">Tournament Standings</a>
-          <a href="rules.html">Server Rules</a>
-          <a href="index.html#news">Server News</a>
-        </div>
-      </div>
-
-      <div class="footer-col">
-        <h4>Contact</h4>
-        <div class="footer-links">
-          <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener noreferrer">Contact Us</a>
-          <a href="faq.html">FAQs</a>
-          <a href="https://forms.gle/2Wp7HmhhMbxEsafM7" target="_blank" rel="noopener noreferrer">Ban Appeal</a>
-          <a href="https://forms.gle/gB6qyvpkKUXfC9jr9" target="_blank" rel="noopener noreferrer">Plugin Suggestions</a>
-          <a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener noreferrer">Whitelist Application</a>
-        </div>
-      </div>
-
-      <div class="footer-col">
-        <h4>External</h4>
-        <div class="footer-links">
-          <a href="vote-links.html">Vote Links</a>
-          <a href="https://www.minecraft.net/en-us/minecraft-tips-for-beginners#getting_started" target="_blank" rel="noopener noreferrer">How to Play</a>
-          <a href="https://www.minecraft.net/" target="_blank" rel="noopener noreferrer">Minecraft.net</a>
-          <a href="https://www.bisecthosting.com/donate/299b5130" target="_blank" rel="noopener noreferrer">Server Donation</a>
-        </div>
-      </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Browse the Pinnacle SMP Season 12 screenshot archive.">
+  <title>Season 12 Gallery | Pinnacle SMP</title>
+  <link rel="icon" href="assets/diamond.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="assets/major-update.css" data-major-update>
+</head>
+<body class="retro-wrapped-page">
+  <div class="site-shell gallery-site-shell">
+    <div class="top-strip">
+      <span>PINNACLE SMP ONLINE NETWORK</span>
+      <span>ONLINE SINCE 2012</span>
     </div>
 
-    <div class="container footer-bottom">
-      © 2026 Pinnacle SMP. All rights reserved. v. 108.6220540
+    <header class="header">
+      <img class="logo" src="assets/logo.svg" alt="Pinnacle SMP">
+      <p class="tagline">COMMUNITY SCREENSHOT ARCHIVE</p>
+    </header>
+
+    <div class="marquee-box" aria-label="Server announcement">
+      <span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY • NOW ACCEPTING NEW MEMBERS</span>
     </div>
-  </footer>
-<script>(()=>{const h=document.querySelector('.site-header');const t=document.querySelector('.menu-toggle');const n=document.getElementById('mobile-nav');if(h&&t&&n){const c=()=>{h.classList.remove('nav-open');t.setAttribute('aria-expanded','false')};t.addEventListener('click',()=>{const o=h.classList.toggle('nav-open');t.setAttribute('aria-expanded',String(o))});n.querySelectorAll('a').forEach((l)=>l.addEventListener('click',c));window.addEventListener('resize',()=>{if(window.innerWidth>860)c()});}})();</script>
-<script src="assets/gallery-season-12-config.js"></script>
-<script src="assets/gallery-season-12.js"></script>
-  <script src="assets/server-status.js"></script>
-  <script src="assets/server-status-badge.js"></script>
-  <script src="assets/particles.js"></script>
-</body></html>
+
+    <div class="main-grid">
+      <aside class="sidebar">
+        <section class="box">
+          <div class="box-title">Main Menu</div>
+          <nav>
+            <ul class="nav-list">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="about.html">About Pinnacle</a></li>
+              <li><a href="season12.html">Season 12</a></li>
+              <li><a href="news.html">Server News</a></li>
+              <li><a href="members.html">Members</a></li>
+              <li><a href="standings.html">Tournament Standings</a></li>
+              <li><a href="gallery.html" class="active">Gallery</a></li>
+              <li><a href="rules.html">Server Rules</a></li>
+              <li><a href="faq.html">FAQs</a></li>
+              <li><a href="links.html">Links &amp; Voting</a></li>
+              <li><a href="join.html">Join / Contact</a></li>
+            </ul>
+          </nav>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Quick Connect</div>
+          <div class="box-body small">
+            <p><strong>Server IP:</strong><br>pinnaclesmp.mcserv.fun</p>
+            <p><strong>Capacity:</strong><br>20 players</p>
+            <p><strong>Edition:</strong><br>Java Edition</p>
+            <p><a href="http://pinnaclesmp.mcserv.fun:1041/" target="_blank" rel="noopener">Live World Map</a></p>
+            <p><a href="https://discord.gg/97hdX25n7F" target="_blank" rel="noopener">Pinnacle Discord</a></p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Cool Links</div>
+          <div class="box-body center">
+            <div class="webring">
+              <a href="members.html">« Members</a>
+              <strong>PINNACLE</strong>
+              <a href="links.html#voting">Vote »</a>
+            </div>
+          </div>
+        </section>
+      </aside>
+
+      <main class="content">
+        <section class="box">
+          <div class="box-title">Season 12 Screenshot Archive</div>
+          <div class="box-body">
+            <nav id="gallery-breadcrumbs" class="gallery-breadcrumbs" aria-label="Breadcrumb"></nav>
+            <h1 id="gallery-title">Season 12 Gallery</h1>
+            <p id="gallery-description">A visual archive of community moments from Pinnacle SMP Season 12.</p>
+            <p id="gallery-status">Loading screenshots…</p>
+            <div id="folder-grid" class="gallery-list" aria-live="polite"></div>
+            <div id="season-gallery-grid" class="season-gallery-grid" aria-live="polite"></div>
+          </div>
+        </section>
+      </main>
+
+      <aside class="rightbar">
+        <section class="box">
+          <div class="box-title">Server Status</div>
+          <div class="box-body center">
+            <p class="status-online"><span class="status-dot unknown" data-live-dot></span><span data-server-status>CHECKING...</span></p>
+            <p><strong data-player-count>— / 20</strong> players</p>
+            <p><span class="server-version" data-server-version>Paper 26.2</span></p>
+            <p class="small"><strong>pinnaclesmp.mcserv.fun</strong></p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Official Emblem</div>
+          <div class="box-body center">
+            <img class="official-logo" src="assets/pinnacle-logo.png" alt="Official Pinnacle SMP logo">
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Web Counter</div>
+          <div class="box-body center">
+            <div class="hit-counter" data-counter>0000000</div>
+            <p class="small">page views since reset</p>
+          </div>
+        </section>
+
+        <section class="box">
+          <div class="box-title">Server Time</div>
+          <div class="box-body center small" data-clock>Loading...</div>
+        </section>
+      </aside>
+    </div>
+
+    <footer class="footer">
+      <div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div>
+      <div><a href="gallery.html">Gallery</a> | <a href="gallery-season-11.html">Season 11</a> | <a href="gallery-season-12.html">Season 12</a></div>
+      <div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div>
+    </footer>
+  </div>
+
+  <script src="assets/gallery-season-12-config.js"></script>
+  <script src="assets/gallery-season-12.js"></script>
+  <script src="assets/script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <img class="logo" src="assets/logo.svg" alt="Pinnacle SMP Minecraft Community — Season 12">
     <p class="tagline">BUILD • EXPLORE • MAKE FRIENDS • BUILD HIGHER</p>
   </header>
-  <div class="marquee-box" aria-label="Server announcement"><span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY • APPLICATIONS TEMPORARILY CLOSED</span></div>
+  <div class="marquee-box" aria-label="Server announcement"><span class="marquee-track">PINNACLE SMP • SEASON 12 • PAPER 26.2 • WHITELISTED VANILLA+ • 18+ COMMUNITY • NOW ACCEPTING NEW MEMBERS</span></div>
   <div class="main-grid">
     <aside class="sidebar">
       <section class="box">
@@ -54,7 +54,7 @@
       <section class="box">
         <div class="box-body">
 <h1>Welcome to <span class="rainbow">Pinnacle SMP!</span></h1>
-<div class="closed-status">MEMBERSHIP NOTICE: Pinnacle SMP is not accepting additional new members at this time.</div>
+<div class="closed-status membership-open-status">MEMBERSHIP NOTICE: Pinnacle SMP is accepting new members.</div>
 <p>Pinnacle SMP is a small, established Minecraft community built around long-term survival worlds, trust, collaborative projects, memorable events, and a welcoming atmosphere. The community comes first and the server comes second.</p>
 <div class="callout center"><strong>WHITELISTED • VANILLA+ • PAPER 26.2 • JAVA EDITION • 18+ ONLY</strong></div>
 <hr class="pixel-rule">

--- a/join.html
+++ b/join.html
@@ -15,7 +15,7 @@
     <img class="logo" src="assets/logo.svg" alt="Pinnacle SMP Minecraft Community — Season 12">
     <p class="tagline">BUILD • EXPLORE • MAKE FRIENDS • BUILD HIGHER</p>
   </header>
-  <div class="marquee-box" aria-label="Server announcement"><span class="marquee-track">PINNACLE SMP • APPLICATIONS TEMPORARILY CLOSED • CURRENT MEMBERS: CHECK DISCORD FOR SERVER INFORMATION</span></div>
+  <div class="marquee-box" aria-label="Server announcement"><span class="marquee-track">PINNACLE SMP • NOW ACCEPTING NEW MEMBERS • CURRENT MEMBERS: CHECK DISCORD FOR SERVER INFORMATION</span></div>
   <div class="main-grid">
     <aside class="sidebar">
       <section class="box">
@@ -55,11 +55,11 @@
         <div class="box-body">
           
 <h1>Join / Contact Pinnacle</h1>
-<div class="closed-status">
-  WHITELIST APPLICATIONS ARE TEMPORARILY CLOSED
+<div class="closed-status membership-open-status">
+  WHITELIST APPLICATIONS ARE OPEN
 </div>
-<p>Pinnacle SMP is not accepting additional new members at this time. This gives the newest members time to settle into the community and allows the server to grow in manageable waves.</p>
-<h2>When Applications Reopen</h2>
+<p>Pinnacle SMP is accepting new members. Applicants should be at least 18 years old, read the complete server rules, and apply through the official Discord process.</p>
+<h2>How to Apply</h2>
 <ol class="rules">
   <li>Confirm that you are at least 18 years old.</li>
   <li>Read the complete server rules.</li>


### PR DESCRIPTION
Updates all site pages to show that Pinnacle SMP is accepting new members and permanently removes the old-design flash from the Season 11 and Season 12 gallery pages.

Changes include:
- replaces closed-application wording in shared marquees and notices
- updates the homepage membership notice
- rewrites the Join page for open applications
- applies the open-membership message across standard, profile, and gallery pages
- rebuilds both gallery source pages directly in the retro shell
- removes the legacy light-theme header, closed-membership banner, particle background, footer, and delayed full-page wrapper from gallery pages
- preserves all Season 12 folder paths, breadcrumbs, Cloudinary image loading, live status, server clock, and page counter
- moves the Season 11 image loader into a dedicated script