### PR TITLE
Add New Member Activity Purge news story

### DIFF
--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -1,9 +1,25 @@
 (() => {
   const ARTICLE = {
+    id: 'new-member-activity-purge',
+    date: 'AUG 06, 2026',
+    archiveDate: 'AUGUST 6, 2026',
+    title: 'New Member Activity Purge — Monday, August 10',
+    summary: 'New Members with 0 playtime will be removed from the whitelist on Monday. Recently accepted players should log in before then to keep their place.',
+    tag: 'Announcement',
+    body: `<p>Just a heads up! This Monday, August 10, Pinnacle SMP will be doing a cleanup of the member list.</p>
+      <p>Any <strong>New Member</strong> who has <strong>0 playtime</strong> on the server will be removed from the whitelist to make room for players who are actively interested in joining the community.</p>
+      <p>If you have recently been accepted but have not had a chance to log in yet, be sure to join the server before Monday—even if it is only for a few minutes—to avoid being removed.</p>
+      <p>If you are removed and later decide you would still like to join us, you are always welcome to submit a new application.</p>
+      <p>Thanks for helping us keep the community active and welcoming!</p>`
+  };
+
+  const PREVIOUS_ARTICLE = {
     id: 'retro-redesign',
     date: 'AUG 04, 2026',
+    archiveDate: 'AUGUST 4, 2026',
     title: "Pinnacle SMP Website Gets a Retro '90s Redesign",
     summary: "The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.",
+    tag: 'Announcement',
     body: `<p>The Pinnacle SMP website has received a complete visual overhaul inspired by the personal websites, gaming fan pages, and community portals of the late 1990s.</p>
       <p>The new design uses classic beveled panels, bright blue title bars, compact sidebars, pixel-style details, scrolling announcements, web counters, and other familiar elements from the early days of the internet. The goal was to give Pinnacle a more distinctive and memorable home while reflecting the community-focused character of the server.</p>
       <p>Although the website now looks intentionally retro, its important modern features remain available. Visitors can still view live server information, open member profiles, browse PinnacleStats dashboards, check tournament standings, read server rules, access voting and contact links, and explore the complete Season 11 and Season 12 screenshot galleries.</p>
@@ -37,7 +53,9 @@
   function updateHome() {
     const isHome = /(^|\/)index\.html$/.test(location.pathname) || location.pathname === '/' || /\/pr-preview\/pr-\d+\/?$/.test(location.pathname);
     if (!isHome) return true;
-    if (document.querySelector('.newest-news-item .new-badge')) return true;
+
+    const currentLink = document.querySelector(`.newest-news-item a[href="news.html#${ARTICLE.id}"]`);
+    if (currentLink) return true;
 
     const heading = [...document.querySelectorAll('main.content h2')].find(el => el.textContent.trim() === 'Latest Server News');
     if (!heading) return false;
@@ -55,7 +73,7 @@
 
     const second = document.createElement('div');
     second.className = 'news-item';
-    second.innerHTML = `<span class="news-date">JUL 02, 2026</span><h3>Recent Plugin Updates and Additions</h3><p>New custom plugins and restored community tools improve protection, shops, activity visibility, Discord updates, mapping, and website statistics.</p><a href="news.html#plugins">Read the full update →</a>`;
+    second.innerHTML = `<span class="news-date">${PREVIOUS_ARTICLE.date}</span><h3>${PREVIOUS_ARTICLE.title}</h3><p>${PREVIOUS_ARTICLE.summary}</p><a href="news.html#${PREVIOUS_ARTICLE.id}">Read the full update →</a>`;
 
     heading.after(first, second);
     return true;
@@ -87,9 +105,6 @@
       return;
     }
 
-    // Only make the newest article the default when the URL is not targeting
-    // another archive entry. An unknown hash leaves the archive's existing
-    // open state untouched rather than overriding the requested destination.
     if (!location.hash) {
       archive.querySelectorAll('details.news-archive-item').forEach(item => {
         item.open = item === newest;
@@ -97,23 +112,33 @@
     }
   }
 
+  function ensureArchiveArticle(archive, article, showNewBadge) {
+    let item = document.getElementById(article.id);
+    if (!(item instanceof HTMLDetailsElement) || !archive.contains(item)) {
+      item = document.createElement('details');
+      item.className = 'news-archive-item';
+      item.id = article.id;
+    }
+
+    const badge = showNewBadge ? '<span class="new-badge">NEW!</span>' : '';
+    item.innerHTML = `<summary><span><span class="news-date">${article.archiveDate}</span><strong>${article.title}${badge}</strong></span><span class="archive-tag">${article.tag}</span></summary><div class="news-archive-body">${article.body}</div>`;
+    return item;
+  }
+
   function updateArchive() {
     if (!/(^|\/)news\.html$/.test(location.pathname)) return true;
     const archive = document.querySelector('.news-archive');
     if (!archive) return false;
-    if (archive.dataset.retroNewsReady === 'true') return true;
+    if (archive.dataset.retroNewsReady === ARTICLE.id) return true;
 
     const intro = archive.previousElementSibling;
     if (intro?.tagName === 'P') intro.textContent = 'Open an article to read it.';
 
-    let newest = document.getElementById(ARTICLE.id);
-    if (!newest) {
-      newest = document.createElement('details');
-      newest.className = 'news-archive-item';
-      newest.id = ARTICLE.id;
-      newest.innerHTML = `<summary><span><span class="news-date">AUGUST 4, 2026</span><strong>${ARTICLE.title}<span class="new-badge">NEW!</span></strong></span><span class="archive-tag">Announcement</span></summary><div class="news-archive-body">${ARTICLE.body}</div>`;
-      archive.prepend(newest);
-    }
+    const previous = ensureArchiveArticle(archive, PREVIOUS_ARTICLE, false);
+    archive.prepend(previous);
+
+    const newest = ensureArchiveArticle(archive, ARTICLE, true);
+    archive.prepend(newest);
 
     openArchiveArticle(archive, newest);
 
@@ -122,7 +147,7 @@
       archive.dataset.hashListenerAdded = 'true';
     }
 
-    archive.dataset.retroNewsReady = 'true';
+    archive.dataset.retroNewsReady = ARTICLE.id;
     return true;
   }
 

--- a/index.html
+++ b/index.html
@@ -81,16 +81,16 @@
 </div>
 <h2>Latest Server News</h2>
 <div class="news-item newest-news-item">
-  <span class="news-date">AUG 04, 2026</span>
-  <h3>Pinnacle SMP Website Gets a Retro '90s Redesign <span class="new-badge">NEW!</span></h3>
-  <p>The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.</p>
-  <a href="news.html#retro-redesign">Read the full update →</a>
+  <span class="news-date">AUG 06, 2026</span>
+  <h3>New Member Activity Purge — Monday, August 10 <span class="new-badge">NEW!</span></h3>
+  <p>New Members with 0 playtime will be removed from the whitelist on Monday. Recently accepted players should log in before then to keep their place.</p>
+  <a href="news.html#new-member-activity-purge">Read the full update →</a>
 </div>
 <div class="news-item">
-  <span class="news-date">JUL 02, 2026</span>
-  <h3>Recent Plugin Updates and Additions</h3>
-  <p>New custom plugins and restored community tools improve protection, shops, activity visibility, Discord updates, mapping, and website statistics.</p>
-  <a href="news.html#plugins">Read the full update →</a>
+  <span class="news-date">AUG 04, 2026</span>
+  <h3>Pinnacle SMP Website Gets a Retro '90s Redesign</h3>
+  <p>The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.</p>
+  <a href="news.html#retro-redesign">Read the full update →</a>
 </div>
 <h2>Upcoming Events</h2>
 <table class="event-table">
@@ -111,7 +111,7 @@
   <section class="box"><div class="box-title">88×31 Zone</div><div class="box-body badge-row"><img src="assets/badge-join.svg" alt="Pinnacle SMP"><img src="assets/badge-html.svg" alt="Season 12 April 2026"><img src="assets/badge-browser.svg" alt="Whitelisted Vanilla Plus"><img src="assets/badge-under.svg" alt="Mature 18 plus only"></div></section>
 </aside>
   </div>
-  <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 4, 2026</div><div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div></footer>
+  <footer class="footer"><div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div><div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 6, 2026</div><div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div></footer>
 </div>
 <script src="assets/script.js"></script>
 <script src="assets/retro-news-update.js"></script>


### PR DESCRIPTION
Adds a new server news announcement dated August 6, 2026 about the New Member activity purge scheduled for Monday, August 10.

## Changes
- features the announcement as the newest homepage story
- moves the August 4 website redesign story into the second homepage position
- adds the complete purge announcement to the collapsible server news archive
- warns recently accepted New Members with 0 playtime to log in before Monday
- explains that removed players may submit a new application later
- updates the homepage content date to August 6, 2026

This PR was created from the separate `new-member-activity-purge-news` branch and is not merged.