### PR TITLE
Add Fall 2026 Build Contest news story

### DIFF
--- a/assets/retro-news-update.js
+++ b/assets/retro-news-update.js
@@ -1,5 +1,36 @@
 (() => {
   const ARTICLE = {
+    id: 'fall-build-2026',
+    date: 'AUG 12, 2026',
+    archiveDate: 'AUGUST 12, 2026',
+    title: '🍂 Pinnacle SMP Fall Build Contest 🍂',
+    summary: 'Build something that captures the feeling of fall, win a prize, and keep your winning build featured at Spawn!',
+    tag: 'Event',
+    body: `<p>Fall is coming to <strong>Pinnacle SMP</strong>, and we're celebrating with a <strong>Fall Build Contest at Spawn!</strong></p>
+      <h3>🎃 Theme: <strong>Autumn Harvest</strong></h3>
+      <p>Build something that captures the feeling of fall! This could be a cozy autumn cottage, pumpkin patch, harvest festival, haunted farmhouse, corn maze, fall market, or anything else that fits the season.</p>
+      <p>All contest builds must be constructed <strong>at Spawn</strong> so everyone can walk around and check out the entries.</p>
+      <h3>🏆 Prizes</h3>
+      <p>🥇 <strong>1st Place:</strong> 32 Diamonds + Fall Build Contest Champion recognition<br>
+      🥈 <strong>2nd Place:</strong> 16 Diamonds<br>
+      🥉 <strong>3rd Place:</strong> 8 Diamonds</p>
+      <p>The winning build will also remain featured at Spawn as part of the season's history!</p>
+      <h3>📜 Contest Rules</h3>
+      <ul>
+        <li>Builds must follow the <strong>Autumn Harvest</strong> theme.</li>
+        <li>All entries must be built at <strong>Spawn</strong>.</li>
+        <li>You may build alone or work with another member.</li>
+        <li>Builds should be created specifically for this contest.</li>
+        <li>Have fun with it! Creativity and atmosphere matter more than simply building the biggest structure.</li>
+      </ul>
+      <p>📅 <strong>Start:</strong> Sep. 1, 2026<br>
+      📅 <strong>Deadline:</strong> Dec. 1, 2026</p>
+      <p>Once the contest ends, the entries will be judged and the winners announced!</p>
+      <p>Grab some pumpkins, leaves, hay bales, and spruce wood and help give Spawn a proper fall makeover. 🍁</p>
+      <p><strong>Good luck, and happy building!</strong></p>`
+  };
+
+  const PREVIOUS_ARTICLE = {
     id: 'new-member-activity-purge',
     date: 'AUG 06, 2026',
     archiveDate: 'AUGUST 6, 2026',
@@ -13,7 +44,7 @@
       <p>Thanks for helping us keep the community active and welcoming!</p>`
   };
 
-  const PREVIOUS_ARTICLE = {
+  const OLDER_ARTICLE = {
     id: 'retro-redesign',
     date: 'AUG 04, 2026',
     archiveDate: 'AUGUST 4, 2026',
@@ -133,6 +164,9 @@
 
     const intro = archive.previousElementSibling;
     if (intro?.tagName === 'P') intro.textContent = 'Open an article to read it.';
+
+    const older = ensureArchiveArticle(archive, OLDER_ARTICLE, false);
+    archive.prepend(older);
 
     const previous = ensureArchiveArticle(archive, PREVIOUS_ARTICLE, false);
     archive.prepend(previous);

--- a/index.html
+++ b/index.html
@@ -81,22 +81,23 @@
 </div>
 <h2>Latest Server News</h2>
 <div class="news-item newest-news-item">
-  <span class="news-date">AUG 06, 2026</span>
-  <h3>New Member Activity Purge — Monday, August 10 <span class="new-badge">NEW!</span></h3>
-  <p>New Members with 0 playtime will be removed from the whitelist on Monday. Recently accepted players should log in before then to keep their place.</p>
-  <a href="news.html#new-member-activity-purge">Read the full update →</a>
+  <span class="news-date">AUG 12, 2026</span>
+  <h3>Fall 2026 Build Contest Starts Sept. 1! <span class="new-badge">NEW!</span></h3>
+  <p>Build something that captures the feeling of fall, win a prize, and keep your winning build featured at Spawn!</p>
+  <a href="news.html#fall-build-2026">Read the full update →</a>
 </div>
 <div class="news-item">
-  <span class="news-date">AUG 04, 2026</span>
-  <h3>Pinnacle SMP Website Gets a Retro '90s Redesign</h3>
-  <p>The Pinnacle SMP website has been rebuilt with a colorful late-'90s internet look while retaining modern server information, member profiles, statistics, galleries, and live tools.</p>
-  <a href="news.html#retro-redesign">Read the full update →</a>
+  <span class="news-date">AUG 06, 2026</span>
+  <h3>New Member Activity Purge - Monday, August 10</h3>
+  <p>New Members with 0 playtime will be removed from the whitelist on Monday. Recently accepted players should log in before then to keep their place.</p>
+  <a href="news.html#new-member-activity-purge">Read the full update →</a>
 </div>
 <h2>Upcoming Events</h2>
 <table class="event-table">
   <thead><tr><th>Event</th><th>Location</th><th>Date</th><th>Time</th></tr></thead>
   <tbody>
-    <tr><td>Tournament #4 — The Great Boat Race</td><td>IG-1</td><td>Rescheduling</td><td>Rescheduling</td></tr>
+    <tr><td>Fall 2026 Build Contest</td><td>N/A</td><td>Sep 1 -</br>Dec 1</td><td>N/A</td></tr>
+    <tr><td>Tournament #4</td><td>IG-1</td><td>Rescheduling</td><td>Rescheduling</td></tr>
     <tr><td>Server Tour #2</td><td>IG-1</td><td>TBD</td><td>TBD</td></tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds the Fall 2026 Build Contest announcement and full server news article.

## Included
- preserves the existing homepage update already on `add-fall-build-event-2026`
- adds the full Fall Build Contest article at `news.html#fall-build-2026`
- includes the Autumn Harvest theme, Spawn requirement, prizes, rules, September 1 start date, and December 1 deadline
- updates the news script so the Fall contest is treated as the newest article instead of overwriting the homepage with the older member-purge story
- keeps the August 6 member purge and August 4 retro redesign stories in the archive

No changes are made directly to `main`.