### PR TITLE
Add Sleepy_Carson as a new member

### DIFF
--- a/members.html
+++ b/members.html
@@ -96,8 +96,9 @@
 <a class="roster-name rank-full" href="profiles/?player=SweetBunny16" data-member-card data-username="SweetBunny16"><img src="assets/player_heads/SweetBunny16.png" alt="SweetBunny16 player head"><span class="roster-text"><strong>SweetBunny16</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
 </div></section>
 
-<section class="roster-section"><h2>New Members<span class="roster-count">1</span></h2><div class="roster-grid">
+<section class="roster-section"><h2>New Members<span class="roster-count">2</span></h2><div class="roster-grid">
 <a class="roster-name rank-new" href="profiles/?player=laurentziu" data-member-card data-username="laurentziu143"><img src="assets/player_heads/laurentziu143.png" alt="laurentziu143 player head"><span class="roster-text"><strong>laurentziu143</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
+<a class="roster-name rank-new" href="profiles/?player=Sleepy_Carson" data-member-card data-username="Sleepy_Carson"><span class="roster-placeholder">?</span><span class="roster-text"><strong>Sleepy_Carson</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
 </div></section>
 
 <section class="roster-section"><h2>Banned<span class="roster-count">2</span></h2><div class="roster-grid">
@@ -105,7 +106,7 @@
 <a class="roster-name rank-banned" href="profiles/?player=Kelly_E" data-member-card data-username="Kelly_E"><img src="assets/player_heads/Kelly_E.png" alt="Kelly_E player head"><span class="roster-text"><strong>Kelly_E</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
 </div></section>
 
-<p class="source-note">Roster information was last updated on August 10, 2026. Member profiles are updated regularly.</p>
+<p class="source-note">Roster information was last updated on August 13, 2026. Member profiles are updated regularly.</p>
         </div>
       </section>
     </main>
@@ -155,7 +156,7 @@
   </div>
   <footer class="footer">
     <div>© 2012–<span data-year></span> Pinnacle SMP. All rights reserved.</div>
-    <div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 10, 2026</div>
+    <div><a href="index.html">Home</a> | <a href="https://forms.gle/iLaR76yLUEnRFyt58" target="_blank" rel="noopener">Contact Staff</a> | Content updated: August 13, 2026</div>
     <div class="small">Pinnacle SMP is not affiliated with or endorsed by Mojang Studios or Microsoft.</div>
   </footer>
 </div>

--- a/profiles/profile-page.js
+++ b/profiles/profile-page.js
@@ -29,6 +29,7 @@
     { key: 'Ratatuii20', player: 'Ratatuii20', head: 'Ratatuii20.png' },
     { key: 'SweetBunny16', player: 'SweetBunny16', head: 'SweetBunny16.png' },
     { key: 'laurentziu', player: 'laurentziu143', head: 'laurentziu143.png', aliases: ['laurentziu143'] },
+    { key: 'Sleepy_Carson', player: 'Sleepy_Carson' },
     { key: 'Ciupi8983', player: 'Ciupi8983', head: 'Ciupi8983.png' },
     { key: 'Kelly_E', player: 'Kelly_E', head: 'Kelly_E.png' }
   ];


### PR DESCRIPTION
Adds Sleepy_Carson to the Pinnacle SMP member roster as a New Member.

## Changes
- adds Sleepy_Carson to the New Members section
- updates the New Members count from 1 to 2
- adds Sleepy_Carson to the shared profile lookup so the member card opens a valid profile
- uses the existing placeholder head because no Sleepy_Carson player-head asset is currently in the repository
- updates the member roster/content date to August 13, 2026

No changes are made directly to `main`.