### PR TITLE
Fix Sleepy_Carson member head

### DIFF
--- a/members.html
+++ b/members.html
@@ -98,7 +98,7 @@
 
 <section class="roster-section"><h2>New Members<span class="roster-count">2</span></h2><div class="roster-grid">
 <a class="roster-name rank-new" href="profiles/?player=laurentziu" data-member-card data-username="laurentziu143"><img src="assets/player_heads/laurentziu143.png" alt="laurentziu143 player head"><span class="roster-text"><strong>laurentziu143</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
-<a class="roster-name rank-new" href="profiles/?player=Sleepy_Carson" data-member-card data-username="Sleepy_Carson"><span class="assets/player_heads/Sleepy_Carson.png">?</span><span class="roster-text"><strong>Sleepy_Carson</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
+<a class="roster-name rank-new" href="profiles/?player=Sleepy_Carson" data-member-card data-username="Sleepy_Carson"><img src="assets/player_heads/Sleepy_Carson.png" alt="Sleepy_Carson player head"><span class="roster-text"><strong>Sleepy_Carson</strong><small><span class="mini-status-dot"></span><span data-member-status>Offline</span></small></span></a>
 </div></section>
 
 <section class="roster-section"><h2>Banned<span class="roster-count">2</span></h2><div class="roster-grid">


### PR DESCRIPTION
Fixes the Sleepy_Carson card on the Members page.

The player head and profile mapping were already correct on `main`, but the Members page used the image path as a CSS class on a placeholder `<span>` instead of rendering an `<img>` element.

This changes only `members.html` so Sleepy_Carson now uses `assets/player_heads/Sleepy_Carson.png` like the other member cards.

No changes are made directly to `main`.